### PR TITLE
Fixed provision scripts.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ansible==2.2.2.0
 APScheduler>=3.3,<3.4
 click>=6
 dateutils==0.6.6
@@ -31,6 +30,5 @@ tornado>=4.4,<5
 Twisted>=16.4,<17
 urllib_kerberos
 websocket-client>=0.40.0,<1
-ansible==2.2.2.0
 boto==2.46.1
 boto3==1.4.4

--- a/vagrant/scripts/install-base.sh
+++ b/vagrant/scripts/install-base.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 
-
 chmod 755 /home/vagrant
 
 yum -y install epel-release

--- a/vagrant/scripts/venv.sh
+++ b/vagrant/scripts/venv.sh
@@ -5,8 +5,10 @@ python3 -m venv --without-pip /opt/treadmill
 source /opt/treadmill/bin/activate
 curl https://bootstrap.pypa.io/get-pip.py | python
 
-pip install --only-binary all -r /home/vagrant/treadmill/requirements.txt
-pip install --only-binary all -r /home/vagrant/treadmill/test-requirements.txt
+pip install numpy
+pip install pandas
+pip install -r /home/vagrant/treadmill/requirements.txt
+pip install -r /home/vagrant/treadmill/test-requirements.txt
 
 cd /home/vagrant/treadmill
 ./setup.py develop


### PR DESCRIPTION
- Fixed provision scripts to install pre-built packages for numpy and pandas.
- For some reason ansible was the root cause, and it caused other problems as
  well - other packages were compiled and some failed.
  As we no longer use ansible and do not plan to, removed without investigating
  why.