### PR TITLE
Adding MANIFEST file to include logging configuration files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include treadmill/logging *


### PR DESCRIPTION
The files in treadmill/logging/* are not included in the Python manifest when packaged into a PEX file. Without them, the packaged treadmill CLI tool crashes whenever a log handler is created.

Adding this path into a MANIFEST.in file prompts setuptools to include these files when packaging and eliminates the crash.