### PR TITLE
Sync with 2017.09.26-2

### DIFF
--- a/lib/python/treadmill/bootstrap/__init__.py
+++ b/lib/python/treadmill/bootstrap/__init__.py
@@ -175,7 +175,8 @@ def _interpolate_list(value, params):
 
 def _interpolate_scalar(value, params):
     """Interpolate string value by rendering the template."""
-    if isinstance(value, str):
+    _LOGGER.debug('value: %r', value)
+    if isinstance(value, (six.string_types, six.text_type)):
         return _render(value, params)
     else:
         # Do not interpolate numbers.

--- a/lib/python/treadmill/gssapiprotocol.py
+++ b/lib/python/treadmill/gssapiprotocol.py
@@ -136,7 +136,7 @@ class GSSServer(GSSBase):
 class GSSAPILineServer(basic.LineReceiver):
     """Line based GSSAPI server."""
 
-    delimiter = '\n'
+    delimiter = b'\n'
 
     def __init__(self):
         self.gss_server = GSSServer()
@@ -174,7 +174,7 @@ class GSSAPILineServer(basic.LineReceiver):
     def write(self, line):
         """Write line back to the client, encrytped and encoded base64."""
         wrapped = self.gss_server.wrap(line)
-        self.sendLine(wrapped)
+        self.sendLine(bytes(wrapped))
 
     def got_line(self, line):
         """Invoked after authentication is done, with decrypted line as arg."""

--- a/lib/python/treadmill/netdev.py
+++ b/lib/python/treadmill/netdev.py
@@ -492,5 +492,5 @@ def _proc_sys_write(path, value):
     assert path.startswith('/proc/sys/')
 
     _LOGGER.debug('Setting %r to %r', path, value)
-    with io.open(path, 'w') as f:
-        f.write(str(value))
+    with io.open(path, 'wb') as f:
+        f.write(str(value).encode(encoding='utf8', errors='replace'))

--- a/lib/python/treadmill/postmortem.py
+++ b/lib/python/treadmill/postmortem.py
@@ -135,8 +135,8 @@ def collect_running_app(approot, destroot):
 def collect_sysctl(destroot):
     """Get host sysctl (related to kernel)."""
     sysctl = subproc.check_output([_SYSCTL, '-a'])
-    with io.open('%s/sysctl' % destroot, 'w') as f:
-        f.write(sysctl)
+    with io.open('%s/sysctl' % destroot, 'wb') as f:
+        f.write(sysctl.encode(encoding='utf8', errors='replace'))
 
 
 def collect_cgroup(approot, destroot):
@@ -186,15 +186,15 @@ def collect_network(approot, destroot):
         _LOGGER.warning('skip %s => %s', src, dest)
 
     ifconfig = subproc.check_output([_IFCONFIG])
-    with io.open('%s/ifconfig' % destroot, 'w') as f:
-        f.write(ifconfig)
+    with io.open('%s/ifconfig' % destroot, 'wb') as f:
+        f.write(ifconfig.encode(encoding='utf8', errors='replace'))
 
 
 def collect_message(destroot):
     """Get messages on the host."""
     dmesg = subproc.check_output([_DMESG])
-    with io.open('%s/dmesg' % destroot, 'w') as f:
-        f.write(dmesg)
+    with io.open('%s/dmesg' % destroot, 'wb') as f:
+        f.write(dmesg.encode(encoding='utf8', errors='replace'))
 
     messages = subproc.check_output(
         [_TAIL, '-n', '100', '/var/log/messages']
@@ -203,5 +203,5 @@ def collect_message(destroot):
     dest_messages = '%s/var/log/messages' % destroot
     if not os.path.exists(os.path.dirname(dest_messages)):
         os.makedirs(os.path.dirname(dest_messages))
-    with io.open(dest_messages, 'w') as f:
-        f.write(messages)
+    with io.open(dest_messages, 'wb') as f:
+        f.write(messages.encode(encoding='utf8', errors='replace'))

--- a/tests/netdev_test.py
+++ b/tests/netdev_test.py
@@ -385,7 +385,7 @@ class NetDevTest(unittest.TestCase):
         netdev.dev_conf_route_localnet_set('foo', True)
 
         io.open.assert_called_with(
-            '/proc/sys/net/ipv4/conf/foo/route_localnet', 'w'
+            '/proc/sys/net/ipv4/conf/foo/route_localnet', 'wb'
         )
         mock_handle.write.assert_called_with('1')
 
@@ -398,7 +398,7 @@ class NetDevTest(unittest.TestCase):
         netdev.dev_conf_proxy_arp_set('foo', True)
 
         io.open.assert_called_with(
-            '/proc/sys/net/ipv4/conf/foo/proxy_arp', 'w'
+            '/proc/sys/net/ipv4/conf/foo/proxy_arp', 'wb'
         )
         mock_handle.write.assert_called_with('1')
 
@@ -411,7 +411,7 @@ class NetDevTest(unittest.TestCase):
         netdev.dev_conf_arp_ignore_set('foo', 2)
 
         io.open.assert_called_with(
-            '/proc/sys/net/ipv4/conf/foo/arp_ignore', 'w'
+            '/proc/sys/net/ipv4/conf/foo/arp_ignore', 'wb'
         )
         mock_handle.write.assert_called_with('2')
 
@@ -424,7 +424,7 @@ class NetDevTest(unittest.TestCase):
         netdev.dev_conf_forwarding_set('foo', True)
 
         io.open.assert_called_with(
-            '/proc/sys/net/ipv4/conf/foo/forwarding', 'w'
+            '/proc/sys/net/ipv4/conf/foo/forwarding', 'wb'
         )
         mock_handle.write.assert_called_with('1')
 


### PR DESCRIPTION
 * Fixed gssapi to work with bytes
 * fixed some issues with the py2to3 migration code
 * use `six.string_types` for `_interpolate_scalar`