### PR TITLE
Sync with 2017.12.12-1

### DIFF
--- a/lib/python/treadmill/admin.py
+++ b/lib/python/treadmill/admin.py
@@ -535,18 +535,39 @@ class Admin(object):
         if not self.ldap:
             raise  # pylint: disable=E0704
 
-    def search(self, search_base, search_filter, search_scope=ldap3.SUBTREE,
-               attributes=None):
-        """Call ldap search and return a list of dn, entry tuples."""
-        self.ldap.search(search_base=search_base,
-                         search_filter=search_filter,
-                         search_scope=search_scope,
-                         attributes=attributes,
-                         dereference_aliases=ldap3.DEREF_NEVER)
-
+    def search(self, search_base, search_filter,
+               search_scope=ldap3.SUBTREE, attributes=None):
+        """Call ldap search and return a generator of dn, entry tuples.
+        """
+        self.ldap.search(
+            search_base=search_base,
+            search_filter=search_filter,
+            search_scope=search_scope,
+            attributes=attributes,
+            dereference_aliases=ldap3.DEREF_NEVER
+        )
         self._test_raise_exceptions()
 
         for entry in self.ldap.response:
+            yield entry['dn'], _dict_normalize(entry['attributes'])
+
+    def paged_search(self, search_base, search_filter,
+                     search_scope=ldap3.SUBTREE, attributes=None):
+        """Call ldap paged search and return a generator of dn, entry tuples.
+        """
+        res_gen = self.ldap.extend.standard.paged_search(
+            search_base=search_base,
+            search_filter=search_filter,
+            search_scope=search_scope,
+            attributes=attributes,
+            dereference_aliases=ldap3.DEREF_NEVER,
+            paged_size=50,
+            paged_criticality=True,
+            generator=True
+        )
+        self._test_raise_exceptions()
+
+        for entry in res_gen:
             yield entry['dn'], _dict_normalize(entry['attributes'])
 
     def _test_raise_exceptions(self):
@@ -595,7 +616,10 @@ class Admin(object):
         """Lists all objects in the database."""
         if not root:
             root = self.root_ou
-        result = self.search(search_base=root, search_filter='(objectClass=*)')
+        result = self.paged_search(
+            search_base=root,
+            search_filter='(objectClass=*)'
+        )
         return [dn for dn, _ in result]
 
     def schema(self, abstract=True):
@@ -603,6 +627,8 @@ class Admin(object):
         # Disable too many branches warning.
         #
         # pylint: disable=R0912
+        #
+        # NOTE: cn=schema,cn=config does *NOT* support paged searches.
         result = self.search(search_base='cn=schema,cn=config',
                              search_filter='(cn={*}treadmill)',
                              search_scope=ldap3.LEVEL,
@@ -870,10 +896,10 @@ class Admin(object):
 
     def get(self, dn, query, attrs):
         """Gets LDAP object given dn."""
-        result = self.search(search_base=dn,
-                             search_filter=six.text_type(query),
-                             search_scope=ldap3.BASE,
-                             attributes=attrs)
+        result = self.paged_search(search_base=dn,
+                                   search_filter=six.text_type(query),
+                                   search_scope=ldap3.BASE,
+                                   attributes=attrs)
         for _dn, entry in result:
             return entry
 
@@ -990,10 +1016,10 @@ class LdapObject(object):
                 query(arg, attrs[obj_field])
 
         _LOGGER.debug('Query: %s', query.to_str())
-        result = self.admin.search(search_base=self.dn(),
-                                   search_filter=query.to_str(),
-                                   search_scope=ldap3.SUBTREE,
-                                   attributes=self.attrs())
+        result = self.admin.paged_search(search_base=self.dn(),
+                                         search_filter=query.to_str(),
+                                         search_scope=ldap3.SUBTREE,
+                                         attributes=self.attrs())
         return [self.from_entry(entry, dn) for dn, entry in result]
 
     def update(self, ident, attrs):
@@ -1024,7 +1050,7 @@ class LdapObject(object):
 
         children_admin = clazz(self.admin)
         attrs = [elem[0] for elem in children_admin.schema()]
-        search = self.admin.search(
+        search = self.admin.paged_search(
             search_base=dn,
             search_filter='(objectclass=%s)' % clazz.oc(),
             attributes=attrs
@@ -1424,7 +1450,7 @@ class Cell(LdapObject):
     def delete(self, ident):
         """Deletes LDAP record."""
         dn = self.dn(ident)
-        cell_partitions = self.admin.search(
+        cell_partitions = self.admin.paged_search(
             search_base=dn,
             search_filter='(objectclass=tmPartition)',
             attributes=[]
@@ -1642,7 +1668,7 @@ class Allocation(LdapObject):
         """Deletes LDAP record."""
         # TODO: need to delete cell allocations as well.
         dn = self.dn(ident)
-        cell_allocs_search = self.admin.search(
+        cell_allocs_search = self.admin.paged_search(
             search_base=dn,
             search_filter='(objectclass=tmCellAllocation)',
             attributes=[]

--- a/lib/python/treadmill/api/app.py
+++ b/lib/python/treadmill/api/app.py
@@ -49,7 +49,7 @@ class API(object):
                 app for app in apps
                 if fnmatch.fnmatch(app['_id'], match)
             ]
-            return sorted(filtered)
+            return sorted(filtered, key=lambda item: item['_id'])
 
         @schema.schema({'$ref': 'app.json#/resource_id'})
         def get(rsrc_id):

--- a/lib/python/treadmill/api/app_group.py
+++ b/lib/python/treadmill/api/app_group.py
@@ -64,7 +64,7 @@ class API(object):
                 app_group for app_group in app_groups
                 if fnmatch.fnmatch(app_group['_id'], match)
             ]
-            return sorted(filtered)
+            return sorted(filtered, key=lambda item: item['_id'])
 
         self.get = get
         self.create = create

--- a/lib/python/treadmill/api/app_monitor.py
+++ b/lib/python/treadmill/api/app_monitor.py
@@ -36,7 +36,7 @@ class API(object):
                 if (monitor is not None and
                     fnmatch.fnmatch(monitor['_id'], match))
             ]
-            return sorted(filtered)
+            return sorted(filtered, key=lambda item: item['_id'])
 
         @schema.schema(
             {'$ref': 'appmonitor.json#/resource_id'},

--- a/lib/python/treadmill/api/cron.py
+++ b/lib/python/treadmill/api/cron.py
@@ -42,7 +42,7 @@ class API(object):
                 if resource and fnmatch.fnmatch(job['resource'], resource):
                     filtered.append(job)
 
-            return sorted(filtered)
+            return sorted(filtered, key=lambda item: item['_id'])
 
         @schema.schema({'$ref': 'cron.json#/resource_id'})
         def get(rsrc_id):

--- a/lib/python/treadmill/api/endpoint.py
+++ b/lib/python/treadmill/api/endpoint.py
@@ -41,7 +41,7 @@ def make_endpoint_watcher(zkclient, state, proid):
             try:
                 endpoint_node = z.join_zookeeper_path(proid_instances, name)
                 data, _metadata = zkclient.get(endpoint_node)
-                endpoints[name] = data
+                endpoints[name] = data.decode()
             except kazoo.client.NoNodeError:
                 pass
 

--- a/lib/python/treadmill/api/identity_group.py
+++ b/lib/python/treadmill/api/identity_group.py
@@ -35,7 +35,7 @@ class API(object):
                 group for group in groups
                 if group is not None and fnmatch.fnmatch(group['_id'], match)
             ]
-            return sorted(filtered)
+            return sorted(filtered, key=lambda item: item['_id'])
 
         @schema.schema(
             {'$ref': 'identity_group.json#/resource_id'},

--- a/lib/python/treadmill/api/scheduler.py
+++ b/lib/python/treadmill/api/scheduler.py
@@ -7,12 +7,56 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import fnmatch
+import logging
+import time
 
 import kazoo.exceptions
 
 from treadmill import context
+from treadmill import exc
 from treadmill import reports
 from treadmill import zknamespace as z
+from treadmill import logcontext as lc
+
+from treadmill import scheduler as tm_sched
+from treadmill.scheduler import loader
+from treadmill.scheduler import zkbackend
+
+_LOGGER = logging.getLogger(__name__)
+_CACHE_TIMEOUT = 180  # 3 mins
+_LAST_CACHE_UPDATE = 0
+_RO_SHEDULER_INSTANCE = None
+
+
+def get_readonly_scheduler():
+    """Prepare a readonly master."""
+    # C0103(invalid-name): invalid variable name
+    # W0603(global-statement): using the global statement
+    # pylint: disable=C0103,W0603
+    global _RO_SHEDULER_INSTANCE, _LAST_CACHE_UPDATE
+    if (time.time() - _LAST_CACHE_UPDATE > _CACHE_TIMEOUT or
+            not _RO_SHEDULER_INSTANCE):
+        tm_sched.DIMENSION_COUNT = 3
+
+        _RO_SHEDULER_INSTANCE = loader.Loader(
+            zkbackend.ZkReadonlyBackend(context.GLOBAL.zk.conn),
+            context.GLOBAL.cell
+        )
+        _RO_SHEDULER_INSTANCE.load_model()
+        _LAST_CACHE_UPDATE = time.time()
+
+    return _RO_SHEDULER_INSTANCE
+
+
+def mk_explainapi():
+    """API factory function returning _ExplainAPI class."""
+
+    class _ExplainAPI(object):
+        """API object implementing the scheduler explain functionality."""
+        def __init__(self):
+            self.get = _explain
+
+    return _ExplainAPI
 
 
 class API(object):
@@ -37,6 +81,7 @@ class API(object):
                 raise KeyError(report_type)
 
         self.get = get
+        self.explain = mk_explainapi()()
 
 
 def _match_by_name(dataframe, report_type, match):
@@ -58,3 +103,27 @@ def _match_by_partition(dataframe, partition):
     partition = fnmatch.translate(partition)
     subidx = dataframe['partition'].str.match(partition)
     return dataframe.loc[subidx].reset_index(drop=True)
+
+
+def _explain(inst_id):
+    """Explain application placement"""
+    with lc.LogContext(_LOGGER, inst_id):
+        start = time.time()
+        ro_scheduler = get_readonly_scheduler()
+        _LOGGER.info('ro_scheduler was ready in %s secs', time.time() - start)
+
+        try:
+            instance = ro_scheduler.cell.apps[inst_id]
+        except KeyError:
+            raise exc.NotFoundError(inst_id)
+
+        if instance.server:
+            raise exc.FoundError(
+                'instance {} is already placed on {}'.format(
+                    inst_id, instance.server
+                )
+            )
+
+        return reports.explain_placement(
+            ro_scheduler.cell, instance, 'servers'
+        )

--- a/lib/python/treadmill/appcfg/manifest.py
+++ b/lib/python/treadmill/appcfg/manifest.py
@@ -295,7 +295,7 @@ def _add_linux_system_services(tm_env, manifest):
     manifest['system_services'].append(register_presence)
 
     # Create container /etc/hosts manager service
-    run_overlay = os.path.join(container_data_dir, 'overlay', 'var', 'run')
+    run_overlay = os.path.join(container_data_dir, 'overlay', 'run')
     etc_overlay = os.path.join(container_data_dir, 'overlay', 'etc')
     hostaliases = {
         'name': 'hostaliases',

--- a/lib/python/treadmill/apptrace/zk.py
+++ b/lib/python/treadmill/apptrace/zk.py
@@ -321,6 +321,8 @@ def cleanup_finished(zkclient, batch_size, expires_after):
     for finished in zkclient.get_children(z.FINISHED):
         node_path = z.path.finished(finished)
         data, metadata = zkclient.get(node_path)
+        if data is not None:
+            data = data.decode()
         if metadata.last_modified < time.time() - expires_after:
             expired.append((node_path, metadata.last_modified, data,
                             z.FINISHED, finished))

--- a/lib/python/treadmill/bootstrap/__init__.py
+++ b/lib/python/treadmill/bootstrap/__init__.py
@@ -208,6 +208,7 @@ def install(package, dst_dir, params, run=None, profile=None):
     aliases_path = [package]
 
     module = plugin_manager.load('treadmill.bootstrap', package)
+    extension_module = None
     if profile:
         extension_name = '{}.{}'.format(package, profile)
         aliases_path.append(extension_name)

--- a/lib/python/treadmill/bootstrap/openldap/linux/etc/openldap/slapd.ldif
+++ b/lib/python/treadmill/bootstrap/openldap/linux/etc/openldap/slapd.ldif
@@ -66,8 +66,8 @@ olcRequires: {{ r }}
 {%- endfor %}
 {%- endif %}
 {%- if masters %}
-olcLimits: dn.exact="{{ backend.rootdn }}" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited
-olcLimits: dn.base=uid={{ backend.owner }},cn=gssapi,cn=auth time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited
+olcLimits: dn.exact="{{ backend.rootdn }}" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited size.pr=unlimited size.prtotal=unlimited
+olcLimits: dn.base=uid={{ backend.owner }},cn=gssapi,cn=auth time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited size.pr=unlimited size.prtotal=unlimited
 {%- endif %}
 {%- for master in masters %}
 olcSyncRepl: rid={{ rid|length }} provider={{ master }} bindmethod=sasl
@@ -75,6 +75,8 @@ olcSyncRepl: rid={{ rid|length }} provider={{ master }} bindmethod=sasl
 {%- if rid.append('1') %}
 {%- endif %}
 {%- endfor %}
+olcSizeLimit: size.soft={{ backend.size_limit | default(500) }} size.hard={{ backend.size_limit | default(500) }} size.pr=unlimited size.prtotal=unlimited
+olcTimeLimit: {{ backend.time_limit | default(3600) }}
 {%- if masters %}
 {%- if uri in masters %}
 # master has mirroring enabled
@@ -88,8 +90,6 @@ olcUpdateref: {{ master }}
 {%- else %}
 # standalone has no extra config #
 {%- endif %}
-olcSizeLimit: {{ backend.size_limit | default(500) }}
-olcTimeLimit: {{ backend.time_limit | default(3600) }}
 {% if uri in masters %}
 dn: olcOverlay=syncprov,olcDatabase={{ backend.name }},cn=config
 objectClass: olcOverlayConfig

--- a/lib/python/treadmill/bootstrap/spawn/linux/init/cellapi/run
+++ b/lib/python/treadmill/bootstrap/spawn/linux/init/cellapi/run
@@ -2,4 +2,4 @@
 
 exec 2>&1
 
-exec {{ treadmill }}/bin/treadmill sproc restapi -s {{ dir }}/cellapi.sock --title 'Treadmill_Cell_API' -m instance --cors-origin='.*'
+exec {{ treadmill }}/bin/treadmill sproc restapi -s {{ dir }}/cellapi.sock --title 'Treadmill_Cell_API' -m instance --backlog 10000 --workers 5 --cors-origin='.*'

--- a/lib/python/treadmill/cli/admin/node.py
+++ b/lib/python/treadmill/cli/admin/node.py
@@ -1,4 +1,6 @@
-"""Implementation of treadmill admin node CLI plugin"""
+"""Implementation of treadmill admin node CLI plugin
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -10,9 +12,10 @@ import shutil
 import click
 
 from treadmill import diskbenchmark
-from treadmill import fs
 from treadmill import localdiskutils
 from treadmill import subproc
+
+from treadmill.fs import linux as fs_linux
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,7 +119,9 @@ def benchmark_group(parent):
             if underlying_device_name is not None:
                 # LVM is based on physical device,
                 # benchmark VG directly
-                underlying_device_uuid = fs.device_uuid(underlying_device_name)
+                underlying_device_uuid = fs_linux.blk_uuid(
+                    underlying_device_name
+                )
                 max_iops_result = diskbenchmark.benchmark_vg(
                     vg_name,
                     benchmark_volume,
@@ -138,9 +143,9 @@ def benchmark_group(parent):
             elif underlying_image_path is not None:
                 # LVM is based on loop device,
                 # benchmark underlying physical device of image file
-                underlying_device_uuid = fs.device_uuid(
-                    fs.maj_min_to_blk(
-                        *fs.path_to_maj_min(underlying_image_path)
+                underlying_device_uuid = fs_linux.blk_uuid(
+                    fs_linux.maj_min_to_blk(
+                        *fs_linux.maj_min_from_path(underlying_image_path)
                     )
                 )
                 benchmark_path = os.path.join(

--- a/lib/python/treadmill/cli/admin/scheduler.py
+++ b/lib/python/treadmill/cli/admin/scheduler.py
@@ -63,6 +63,8 @@ def view_group(parent):
                 print(output.to_csv())
             else:
                 pd.set_option('expand_frame_repr', False)
+                output.replace(True, ' ', inplace=True)
+                output.replace(False, 'X', inplace=True)
                 print(output)
 
     @parent.group()

--- a/lib/python/treadmill/cli/scheduler/explain.py
+++ b/lib/python/treadmill/cli/scheduler/explain.py
@@ -1,0 +1,46 @@
+"""Explain why an application instance is in pending state."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import click
+import pandas as pd
+
+from six.moves import urllib
+
+from treadmill import (cli, context)
+from treadmill.cli.scheduler import print_report
+from treadmill import restclient
+
+# let's handle HTTP 302 (AlreadyExistsError in the explain() func. locally
+_EXCEPTIONS = [
+    ex for ex in restclient.CLI_REST_EXCEPTIONS
+    if ex[0] != restclient.AlreadyExistsError
+]
+
+
+def init():
+    """Return top level command handler."""
+
+    @click.command()
+    @cli.handle_exceptions(_EXCEPTIONS)
+    @click.argument('instance')
+    @click.pass_context
+    def explain(ctx, instance):
+        """Explain why an instance is pending."""
+        api_urls = context.GLOBAL.cell_api(ctx.obj.get('api'))
+        path = '/scheduler/explain/{}'.format(urllib.parse.quote(instance))
+
+        try:
+            response = restclient.get(api_urls, path).json()
+        except restclient.AlreadyExistsError:
+            cli.out('Instance {} is running.'.format(instance))
+        else:
+            report = pd.DataFrame(
+                response['data'], columns=response['columns']
+            )
+            print_report(report)
+
+    return explain

--- a/lib/python/treadmill/fs/linux.py
+++ b/lib/python/treadmill/fs/linux.py
@@ -1,0 +1,305 @@
+"""Linux specific mount and filesystem utilities and wrappers.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import glob
+import io
+import logging
+import os
+import re
+
+import six
+
+if six.PY2 and os.name == 'posix':
+    import subprocess32 as subprocess  # pylint: disable=import-error
+else:
+    import subprocess  # pylint: disable=wrong-import-order
+
+
+from treadmill import exc
+from treadmill import fs
+from treadmill import subproc
+from treadmill.syscall import mount
+
+_LOGGER = logging.getLogger(__name__)
+
+_UUID_RE = re.compile(r'.*UUID="(.*?)".*')
+
+
+###############################################################################
+# Mount utilities
+
+def umount_filesystem(target_dir):
+    """umount filesystem on target directory.
+    """
+    return mount.unmount(target=target_dir)
+
+
+def mount_filesystem(block_dev, target_dir, fs_type='ext4'):
+    """Mount filesystem on target directory.
+
+    :param block_dev:
+        Block device to mount
+    """
+    return mount.mount(
+        source=block_dev,
+        target=target_dir,
+        fs_type=fs_type,
+        mnt_flags=(
+            mount.MS_NOATIME,
+            mount.MS_NODIRATIME,
+        )
+    )
+
+
+def mount_bind(newroot, target, source=None, recursive=True, read_only=True):
+    """Bind mounts `source` to `newroot/target` so that `source` is accessed
+    when reaching `newroot/target`.
+
+    If a directory, the source will be mounted using --rbind.
+    """
+    # Ensure root directory exists
+    if not os.path.exists(newroot):
+        raise exc.ContainerSetupError('Path %r does not exist' % newroot)
+
+    if source is None:
+        source = target
+
+    target = fs.norm_safe(target)
+    source = fs.norm_safe(source)
+
+    # Make sure target directory exists.
+    if not os.path.exists(source):
+        raise exc.ContainerSetupError('Source path %r does not exist' % source)
+
+    mnt_flags = [mount.MS_BIND]
+
+    # Use --rbind for directories and --bind for files.
+    if recursive and os.path.isdir(source):
+        mnt_flags.append(mount.MS_REC)
+
+    # Strip leading /, ensure that mount is relative path.
+    while target.startswith('/'):
+        target = target[1:]
+
+    # Create mount directory, make sure it does not exists.
+    target_fp = os.path.join(newroot, target)
+    if os.path.isdir(source):
+        fs.mkdir_safe(target_fp)
+    else:
+        fs.mkfile_safe(target_fp)
+
+    res = mount.mount(source=source, target=target_fp,
+                      fs_type=None, mnt_flags=mnt_flags)
+    if read_only:
+        res = mount.mount(source=None, target=target_fp,
+                          fs_type=None, mnt_flags=(mount.MS_BIND,
+                                                   mount.MS_RDONLY,
+                                                   mount.MS_REMOUNT))
+
+    return res
+
+
+def mount_proc(newroot, target='proc'):
+    """Mounts /proc directory on newroot.
+    """
+    while target.startswith('/'):
+        target = target[1:]
+
+    return mount.mount(
+        source='proc',
+        target=os.path.join(newroot, target),
+        fs_type='proc'
+    )
+
+
+def mount_sysfs(newroot, target='sys', read_only=True):
+    """Mounts /sysfs directory on newroot.
+    """
+    while target.startswith('/'):
+        target = target[1:]
+
+    mnt_flags = []
+    if read_only:
+        mnt_flags.append(mount.MS_RDONLY)
+
+    return mount.mount(
+        source='sysfs',
+        target=os.path.join(newroot, target),
+        fs_type='sysfs',
+        mnt_flags=mnt_flags
+    )
+
+
+def mount_tmpfs(newroot, target, size=None):
+    """Mounts directory on tmpfs.
+    """
+    while target.startswith('/'):
+        target = target[1:]
+
+    mnt_opts = {}
+    if size is not None:
+        mnt_opts['size'] = size
+
+    return mount.mount(
+        source='tmpfs',
+        target=os.path.join(newroot, target),
+        fs_type='tmpfs',
+        mnt_flags=(
+            mount.MS_NOATIME,
+            mount.MS_NODIRATIME,
+        ),
+        mnt_opts=mnt_opts
+    )
+
+
+###############################################################################
+# Filesystem management
+
+def blk_fs_create(block_dev):
+    """Create a new filesystem for an application of a given size formatted as
+    ext4.
+
+    :param block_dev:
+        Block device where to create the new filesystem
+    :type block_dev:
+        ``str``
+    """
+    subproc.check_call(
+        [
+            'mke2fs',
+            '-F',
+            '-E', 'lazy_itable_init=1,nodiscard',
+            '-O', 'uninit_bg',
+            block_dev
+        ]
+    )
+
+
+def blk_fs_test(block_dev):
+    """Test the existence of a filesystem on a given block device.
+
+    We essentially try to read the superblock and assume no filesystem if we
+    fail.
+
+    :param block_dev:
+        Block device where to create the new filesystem.
+    :type block_dev:
+        ``str``
+    :returns ``bool``:
+        True if the block device contains a filesystem.
+    """
+    res = subproc.call(
+        [
+            'tune2fs',
+            '-l',
+            block_dev
+        ]
+    )
+    return bool(res == 0)
+
+
+def blk_fs_info(block_dev):
+    """Returns blocks group information for the filesystem present on
+    block_dev.
+
+    :param block_dev:
+        Block device for the filesystem info to query.
+    :type block_dev:
+        ``str``
+    :returns:
+        Blocks group information.
+    :rtype:
+        ``dict``
+    """
+    res = {}
+
+    # TODO: it might worth to convert the appropriate values to int, date etc.
+    #       in the result.
+    try:
+        output = subproc.check_output(['dumpe2fs', '-h', block_dev])
+    except subprocess.CalledProcessError:
+        return res
+
+    for line in output.split(os.linesep):
+        if not line.strip():
+            continue
+
+        key, val = line.split(':', 1)
+        res[key.lower()] = val.strip()
+
+    return res
+
+
+def blk_uuid(block_dev):
+    """Get device uuid
+    """
+    output = subproc.check_output(['blkid', block_dev])
+    match_obj = _UUID_RE.match(output)
+    if match_obj is None:
+        raise ValueError('Invalid device: %s' % block_dev)
+    else:
+        return match_obj.group(1)
+
+
+def blk_maj_min(block_dev):
+    """Returns major/minor device numbers for the given block device.
+    """
+    dev_stat = os.stat(os.path.realpath(block_dev))
+    return os.major(dev_stat.st_rdev), os.minor(dev_stat.st_rdev)
+
+
+###############################################################################
+# Major:Minor utilities
+
+def maj_min_to_blk(major, minor):
+    """Returns the block device name to the major:minor numbers in the param.
+
+    :param major:
+        The major number of the device
+    :param minor:
+        The minor number of the device
+    :returns:
+        Block device name.
+    :rtype:
+        ``str``
+    """
+    # TODO: Reimplement using /proc/partition
+    maj_min = '{}:{}'.format(major, minor)
+    block_dev = None
+    for sys_path in glob.glob(os.path.join(os.sep, 'sys', 'class', 'block',
+                                           '*', 'dev')):
+        with io.open(sys_path) as f:
+            if f.read().strip() == maj_min:
+                block_dev = '/dev/{}'.format(sys_path.split(os.sep)[-2])
+                break
+
+    return block_dev
+
+
+def maj_min_from_path(path):
+    """Returns major/minor device numbers for the given path.
+    """
+    dev_stat = os.stat(os.path.realpath(path))
+    return os.major(dev_stat.st_dev), os.minor(dev_stat.st_dev)
+
+
+###############################################################################
+
+__all__ = [
+    'blk_fs_create',
+    'blk_fs_info',
+    'blk_fs_test',
+    'blk_maj_min',
+    'blk_uuid',
+    'maj_min_from_path',
+    'maj_min_to_blk',
+    'mount_bind',
+    'mount_filesystem',
+    'mount_tmpfs',
+    'umount_filesystem',
+]

--- a/lib/python/treadmill/logcontext.py
+++ b/lib/python/treadmill/logcontext.py
@@ -50,6 +50,13 @@ class Adapter(logging.LoggerAdapter):
         """Format the 'extra' content as it will be represented in the logs."""
         return extra
 
+    def isEnabledFor(self, level):
+        """Is this logger enabled for level 'level'?
+
+        Monkey patched so Adapters can be passed to LogContext below.
+        """
+        return self.logger.isEnabledFor(level)
+
 
 class ContainerAdapter(Adapter):
     """

--- a/lib/python/treadmill/metrics/__init__.py
+++ b/lib/python/treadmill/metrics/__init__.py
@@ -20,6 +20,7 @@ from treadmill import fs
 from treadmill import psmem
 from treadmill import yamlwrapper as yaml
 
+from treadmill.fs import linux as fs_linux
 
 NANOSECS_PER_10MILLI = 10000000
 
@@ -192,7 +193,7 @@ def get_fs_usage(block_dev):
     if block_dev is None:
         return {}
 
-    fs_info = fs.read_filesystem_info(block_dev)
+    fs_info = fs_linux.blk_fs_info(block_dev)
     return {'fs.used_bytes': calc_fs_usage(fs_info)}
 
 

--- a/lib/python/treadmill/metrics/engine.py
+++ b/lib/python/treadmill/metrics/engine.py
@@ -12,11 +12,11 @@ import os
 import threading
 import time
 
-
 from treadmill import appenv
 from treadmill import exc
-from treadmill import fs
 from treadmill import metrics
+
+from treadmill.fs import linux as fs_linux
 
 CORE_GROUPS = [
     'apps',
@@ -47,8 +47,12 @@ class CgroupReader(object):
         self._tm_env = appenv.AppEnvironment(root=approot)
         self._sys_svcs = _sys_svcs(approot)
         # TODO: sys_maj_min will be used changing treadmill.metrics.app_metrics
-        self._sys_maj_min = '{}:{}'.format(*fs.path_to_maj_min(approot))
-        self._sys_block_dev = fs.maj_min_to_blk(*fs.path_to_maj_min(approot))
+        self._sys_maj_min = '{}:{}'.format(
+            *fs_linux.maj_min_from_path(approot)
+        )
+        self._sys_block_dev = fs_linux.maj_min_to_blk(
+            *fs_linux.maj_min_from_path(approot)
+        )
 
         # if interval is zero, we just read one time
         if interval <= 0:

--- a/lib/python/treadmill/reports.py
+++ b/lib/python/treadmill/reports.py
@@ -388,10 +388,7 @@ def explain_placement(cell, app, mode):
         'partition', 'traits', 'affinity', 'state', 'lifetime',
         'memory', 'cpu', 'disk', 'name'
     ]
-    df = pd.DataFrame(result, columns=columns)
-    df.replace(True, '.', inplace=True)
-    df.replace(False, 'x', inplace=True)
-    return df
+    return pd.DataFrame(result, columns=columns)
 
 
 def serialize_dataframe(report, compressed=True):

--- a/lib/python/treadmill/rest/api/scheduler.py
+++ b/lib/python/treadmill/rest/api/scheduler.py
@@ -42,13 +42,18 @@ def init(api, cors, impl):
         default=None,
     )
 
+    def report_to_dict(report):
+        """Transform the report to a dict and remove unnecessary attributes."""
+        dict_ = report.to_dict(orient='split')
+        del dict_['index']  # just a list of 0 to n, not useful
+        return dict_
+
     def fetch_report(report_type, match=None, partition=None):
         """Fetch the report from the impl and return it as json."""
         status = 200
         try:
             report = impl.get(report_type, match=match, partition=partition)
-            output = report.to_dict(orient='split')
-            del output['index']  # just a list of 0 to n, not useful
+            output = report_to_dict(report)
         except KeyError:
             output = {
                 'message': 'No such scheduler report: {}'.format(report_type),
@@ -107,3 +112,14 @@ def init(api, cors, impl):
             """Return the apps report."""
             args = arg_parser.parse_args()
             return fetch_report('apps', **args)
+
+    @namespace.route('/explain/<instance>')
+    class _ExplainResource(restplus.Resource):
+        """Explain resource."""
+
+        @webutils.raw_get_api(api, cors)
+        def get(self, instance):
+            """Return scheduler's response."""
+            output = report_to_dict(impl.explain.get(instance))
+            return flask.Response(flask.json.dumps(output),
+                                  mimetype='application/json')

--- a/lib/python/treadmill/runtime/linux/_run.py
+++ b/lib/python/treadmill/runtime/linux/_run.py
@@ -1,5 +1,5 @@
-""" Manages Treadmill applications lifecycle."""
-
+""" Manages Treadmill applications lifecycle.
+"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -21,6 +21,7 @@ from treadmill import plugin_manager
 from treadmill import runtime
 from treadmill import subproc
 
+from treadmill.fs import linux as fs_linux
 from treadmill.syscall import unshare
 
 from . import image
@@ -271,10 +272,10 @@ def _create_root_dir(container_dir, localdisk):
     # container_dir/<subdir>
     root_dir = os.path.join(container_dir, 'root')
 
-    already_initialized = fs.test_filesystem(localdisk['block_dev'])
+    already_initialized = fs_linux.blk_fs_test(localdisk['block_dev'])
     if not already_initialized:
         # Format the block device
-        fs.create_filesystem(localdisk['block_dev'])
+        fs_linux.blk_fs_create(localdisk['block_dev'])
 
     _LOGGER.info('Creating container root directory: %s', root_dir)
     # Creates directory that will serve as new root.
@@ -282,6 +283,6 @@ def _create_root_dir(container_dir, localdisk):
     # Unshare the mount namespace
     unshare.unshare(unshare.CLONE_NEWNS)
     # Mount the container root volume
-    fs.mount_filesystem(localdisk['block_dev'], root_dir)
+    fs_linux.mount_filesystem(localdisk['block_dev'], root_dir)
 
     return root_dir

--- a/lib/python/treadmill/runtime/linux/image/native.py
+++ b/lib/python/treadmill/runtime/linux/image/native.py
@@ -22,6 +22,8 @@ from treadmill import subproc
 from treadmill import supervisor
 from treadmill import utils
 
+from treadmill.fs import linux as fs_linux
+
 from . import fs as image_fs
 from . import _image_base
 from . import _repository_base
@@ -70,9 +72,11 @@ def create_environ_dir(container_dir, root_dir, app):
 
     # Bind the environ directory in the container volume
     fs.mkdir_safe(os.path.join(root_dir, _CONTAINER_ENV_DIR))
-    fs.mount_bind(root_dir, os.path.join('/', _CONTAINER_ENV_DIR),
-                  target=os.path.join(container_dir, _CONTAINER_ENV_DIR),
-                  bind_opt='--bind')
+    fs_linux.mount_bind(
+        root_dir, os.path.join(os.sep, _CONTAINER_ENV_DIR),
+        source=os.path.join(container_dir, _CONTAINER_ENV_DIR),
+        recursive=False, read_only=True
+    )
 
 
 def create_supervision_tree(container_dir, root_dir, app, cgroups_path):
@@ -149,65 +153,75 @@ def create_supervision_tree(container_dir, root_dir, app, cgroups_path):
 
     # Bind the service directory in the container volume
     fs.mkdir_safe(os.path.join(root_dir, 'services'))
-    fs.mount_bind(root_dir, '/services',
-                  target=os.path.join(container_dir, 'services'),
-                  bind_opt='--bind')
+    fs_linux.mount_bind(
+        root_dir, os.path.join(os.sep, 'services'),
+        source=os.path.join(container_dir, 'services'),
+        recursive=False, read_only=False
+    )
 
 
-def make_fsroot(root_dir, proid):
+def make_fsroot(root_dir):
     """Initializes directory structure for the container in a new root.
+
+    The container uses pretty much a blank a FHS 3 layout.
 
      - Bind directories in parent / (with exceptions - see below.)
      - Skip /tmp, create /tmp in the new root with correct permissions.
      - Selectively create / bind /var.
        - /var/tmp (new)
-       - /var/logs (new)
+       - /var/log (new)
        - /var/spool - create empty with dirs.
      - Bind everything in /var, skipping /spool/tickets
      """
     newroot_norm = fs.norm_safe(root_dir)
-    mounts = [
-        '/bin',
-        '/common',
-        '/dev',
-        '/etc',
-        '/lib',
-        '/lib64',
-        '/mnt',
-        '/proc',
-        '/sbin',
-        '/srv',
-        '/sys',
-        '/usr',
-        '/var/tmp/treadmill/env',
-        '/var/tmp/treadmill/spool',
-    ]
 
     emptydirs = [
-        '/tmp',
+        '/bin',
+        '/dev',
+        '/etc',
+        '/home',
+        '/lib',
+        '/lib64',
         '/opt',
-        '/var/spool/keytabs',
-        '/var/spool/tickets',
-        '/var/spool/tokens',
+        '/proc',
+        '/run',
+        '/sbin',
+        '/sys',
+        '/tmp',
+        '/usr',
+        '/var/cache',
+        '/var/lib',
+        '/var/lock',
+        '/var/log',
+        '/var/opt',
+        '/var/spool',
         '/var/tmp',
-        '/var/tmp/cores',
     ]
 
     stickydirs = [
-        '/tmp',
         '/opt',
-        '/var/spool/keytabs',
-        '/var/spool/tickets',
-        '/var/spool/tokens',
+        '/run',
+        '/tmp',
+        '/var/cache',
+        '/var/lib',
+        '/var/lock',
+        '/var/log',
+        '/var/opt',
         '/var/tmp',
-        '/var/tmp/cores/',
     ]
 
     # these folders are shared with underlying host and other containers,
-    # make them readonly to container
-    for mount in mounts:
-        if os.path.exists(mount):
-            fs.mount_bind(newroot_norm, mount, remount_opts=['ro'])
+    mounts = [
+        '/bin',
+        '/etc',  # TODO: Add /etc/opt
+        '/lib',
+        '/lib64',
+        '/sbin',
+        '/usr',
+        # TODO: Remove below once PAM UDS is implemented
+        '/var/tmp/treadmill/env',
+        '/var/tmp/treadmill/spool',
+    ]
 
     for directory in emptydirs:
         fs.mkdir_safe(newroot_norm + directory)
@@ -215,26 +229,34 @@ def make_fsroot(root_dir, proid):
     for directory in stickydirs:
         os.chmod(newroot_norm + directory, 0o777 | stat.S_ISVTX)
 
-    # Mount .../tickets .../keytabs on tempfs, so that they will be cleaned
-    # up when the container exits.
-    #
-    # TODO: Do we need to have a single mount for all tmpfs dirs?
-    for tmpfsdir in ['/var/spool/tickets', '/var/spool/keytabs',
-                     '/var/spool/tokens']:
-        fs.mount_tmpfs(newroot_norm, tmpfsdir, '4M')
+    fs_linux.mount_proc(newroot_norm)
+    fs_linux.mount_sysfs(newroot_norm)
+    # TODO: For security, /dev/ should be minimal and separated to each
+    #       container.
+    fs_linux.mount_bind(
+        newroot_norm, '/dev',
+        recursive=True, read_only=False
+    )
+    # Per FHS3 /var/run should be a symlink to /run which should be tmpfs
+    fs.symlink_safe(
+        os.path.join(newroot_norm, 'var', 'run'),
+        '/run'
+    )
+    # We create an unbounded tmpfs mount so that runtime data can be written to
+    # it, counting against the memory limit of the container.
+    fs_linux.mount_tmpfs(newroot_norm, '/run')
 
-    userdirs = [
-        '/home',
-    ]
+    # Make shared directories/files readonly to container
+    for mount in mounts:
+        if os.path.exists(mount):
+            fs_linux.mount_bind(
+                newroot_norm, mount,
+                recursive=True, read_only=True
+            )
 
-    pwnam = pwd.getpwnam(proid)
-    for directory in userdirs:
-        fs.mkdir_safe(newroot_norm + directory)
-        os.chown(newroot_norm + directory, pwnam.pw_uid, pwnam.pw_gid)
 
-
-def create_etc_overlay(tm_env, container_dir, root_dir, app):
-    """Create overlay configuration (etc) files for the container.
+def create_overlay(tm_env, container_dir, root_dir, app):
+    """Create overlay configuration files for the container.
     """
     # ldpreloads
     _prepare_ldpreload(container_dir, app)
@@ -247,7 +269,7 @@ def create_etc_overlay(tm_env, container_dir, root_dir, app):
     # constructed keytab.
     _prepare_krb(tm_env, container_dir)
     # bind prepared inside container
-    _bind_etc_overlay(container_dir, root_dir)
+    _bind_overlay(container_dir, root_dir)
 
 
 def _prepare_krb(tm_env, container_dir):
@@ -306,12 +328,11 @@ def _prepare_hosts(container_dir, app):
     overlay/
         /etc/
             hosts           # hosts file to be bind mounted in container.
-        /var/run/
+        /run/
             /host-aliases/  # Directory to be bind mounted in container.
     """
     etc_dir = os.path.join(container_dir, 'overlay', 'etc')
-    ha_dir = os.path.join(container_dir, 'overlay',
-                          'var', 'run', 'host-aliases')
+    ha_dir = os.path.join(container_dir, 'overlay', 'run', 'host-aliases')
     fs.mkdir_safe(etc_dir)
     fs.mkdir_safe(ha_dir)
 
@@ -358,7 +379,7 @@ def _prepare_resolv_conf(tm_env, container_dir):
     )
 
 
-def _bind_etc_overlay(container_dir, root_dir):
+def _bind_overlay(container_dir, root_dir):
     """Create the overlay in the container."""
     # Overlay overrides container configs
     #   - /etc/resolv.conf, so that container always uses dnscache.
@@ -370,27 +391,36 @@ def _bind_etc_overlay(container_dir, root_dir):
                          'etc/krb5.keytab',
                          'etc/ld.so.preload',
                          'etc/pam.d/sshd',
-                         'etc/resolv.conf',
-                         'var/run/host-aliases']:
-        fs.mount_bind(root_dir, os.path.join('/', overlay_file),
-                      target=os.path.join(overlay_dir, overlay_file),
-                      bind_opt='--bind')
+                         'etc/resolv.conf']:
+        fs_linux.mount_bind(
+            root_dir, os.path.join(os.sep, overlay_file),
+            source=os.path.join(overlay_dir, overlay_file),
+            recursive=False, read_only=True)
+
+    # Mount host-aliases as read-write
+    fs_linux.mount_bind(
+        root_dir, os.path.join(os.sep, 'run', 'host-aliases'),
+        source=os.path.join(overlay_dir, 'run', 'host-aliases'),
+        recursive=False, read_only=False
+    )
 
     # Also override resolv.conf in the current mount namespace so that
     # system services have access to our resolver.
-    fs.mount_bind('/', '/etc/resolv.conf',
-                  target=os.path.join(overlay_dir, 'etc/resolv.conf'),
-                  bind_opt='--bind')
+    fs_linux.mount_bind(
+        '/', '/etc/resolv.conf',
+        source=os.path.join(overlay_dir, 'etc/resolv.conf'),
+        recursive=False, read_only=True
+    )
 
 
 def get_cgroup_path(app):
     """Gets the path of the cgroup."""
     unique_name = appcfg.app_unique_name(app)
     cgrp = os.path.join('treadmill', 'apps', unique_name)
-    return cgroups.makepath('memory', cgrp)
+    return cgrp
 
 
-def share_cgroup_info(root_dir, cgroup_path):
+def share_cgroup_info(root_dir, cgrp):
     """Shares subset of cgroup tree with the container."""
     # Bind /cgroup/memory inside chrooted environment to /cgroup/.../memory
     # of the container.
@@ -399,10 +429,14 @@ def share_cgroup_info(root_dir, cgroup_path):
     #        exposed (readonly). This is so that tools that
     #        (correctly) read /proc/self/cgroups can access cgroup
     #        data.
-    fs.mkdir_safe(os.path.join(root_dir, 'cgroup', 'memory'))
-    fs.mount_bind(root_dir,
-                  os.path.join('/cgroup', 'memory'),
-                  cgroup_path)
+    shared_subsystems = ['memory']
+    for subsystem in shared_subsystems:
+        fs.mkdir_safe(os.path.join(root_dir, 'cgroup', subsystem))
+        fs_linux.mount_bind(
+            root_dir, os.path.join(os.sep, 'cgroup', subsystem),
+            source=cgroups.makepath(subsystem, cgrp),
+            recursive=True, read_only=False
+        )
 
 
 class NativeImage(_image_base.Image):
@@ -415,7 +449,7 @@ class NativeImage(_image_base.Image):
         self.tm_env = tm_env
 
     def unpack(self, container_dir, root_dir, app):
-        make_fsroot(root_dir, app.proid)
+        make_fsroot(root_dir)
 
         image_fs.configure_plugins(self.tm_env, container_dir, app)
 
@@ -425,13 +459,14 @@ class NativeImage(_image_base.Image):
         shutil.copy(os.path.join(container_dir, runtime.STATE_JSON),
                     os.path.join(root_dir, appcfg.APP_JSON))
 
-        cgroups_path = get_cgroup_path(app)
+        cgrp = get_cgroup_path(app)
 
         create_environ_dir(container_dir, root_dir, app)
-        create_supervision_tree(container_dir, root_dir, app, cgroups_path)
-        create_etc_overlay(self.tm_env, container_dir, root_dir, app)
+        create_supervision_tree(container_dir, root_dir, app,
+                                cgroups_path=cgroups.makepath('memory', cgrp))
+        create_overlay(self.tm_env, container_dir, root_dir, app)
 
-        share_cgroup_info(root_dir, cgroups_path)
+        share_cgroup_info(root_dir, cgrp)
 
 
 class NativeImageRepository(_repository_base.ImageRepository):

--- a/lib/python/treadmill/spawn/manifest_watch.py
+++ b/lib/python/treadmill/spawn/manifest_watch.py
@@ -41,6 +41,10 @@ class ManifestWatch(object):
         fs.mkdir_safe(self.paths.manifest_dir)
         os.chmod(self.paths.manifest_dir, 0o1777)
 
+        tmp_path = os.path.join(self.paths.manifest_dir, '.tmp')
+        fs.mkdir_safe(tmp_path)
+        os.chmod(tmp_path, 0o1777)
+
     def _check_path(self, path):
         """Checks if the path is valid."""
         if not os.path.exists(path):

--- a/lib/python/treadmill/sproc/host_ring.py
+++ b/lib/python/treadmill/sproc/host_ring.py
@@ -40,7 +40,7 @@ def init():
                   envvar='TREADMILL_WSAPI')
     @click.option('--aliases-dir', required=True,
                   help='Host aliases dir.',
-                  default='/var/run/host-aliases')
+                  default='/run/host-aliases')
     def host_ring(api, wsapi, aliases_dir):
         """Manage /etc/hosts file inside the container."""
         ctx['api'] = api

--- a/lib/python/treadmill/sproc/metrics.py
+++ b/lib/python/treadmill/sproc/metrics.py
@@ -22,6 +22,7 @@ from treadmill import exc
 from treadmill import fs
 from treadmill import restclient
 from treadmill import rrdutils
+from treadmill.fs import linux as fs_linux
 from treadmill.metrics import rrd
 
 #: Metric collection interval (every X seconds)
@@ -181,7 +182,7 @@ def init():
             if metric_name.endswith('.rrd')
         )
 
-        sys_maj_min = '{}:{}'.format(*fs.path_to_maj_min(approot))
+        sys_maj_min = '{}:{}'.format(*fs_linux.maj_min_from_path(approot))
         _LOGGER.info('Device sys maj:min = %s for approot: %s',
                      sys_maj_min, approot)
 

--- a/lib/python/treadmill/sproc/presence.py
+++ b/lib/python/treadmill/sproc/presence.py
@@ -67,16 +67,19 @@ def _start_service_sup(tm_env, manifest, container_dir):
 
 def _get_tickets(manifest, container_dir):
     """Get tickets."""
-    principals = manifest.get('tickets', [])
+    principals = set(manifest.get('tickets', []))
     if not principals:
         return False
 
     tkts_spool_dir = os.path.join(
         container_dir, 'root', 'var', 'spool', 'tickets')
 
-    reply = tickets.request_tickets(context.GLOBAL.zk.conn, manifest['name'])
-    if reply:
-        tickets.store_tickets(reply, tkts_spool_dir)
+    tickets.request_tickets(
+        context.GLOBAL.zk.conn,
+        manifest['name'],
+        tkts_spool_dir,
+        principals
+    )
 
     # Check that all requested tickets are valid.
     for princ in principals:
@@ -97,12 +100,11 @@ def _refresh_tickets(manifest, container_dir):
     tkts_spool_dir = os.path.join(container_dir, 'root', 'var', 'spool',
                                   'tickets')
 
-    reply = tickets.request_tickets(context.GLOBAL.zk.conn,
-                                    manifest['name'])
-    if reply:
-        tickets.store_tickets(reply, tkts_spool_dir)
-    else:
-        _LOGGER.error('Error requesting tickets.')
+    principals = set(manifest.get('tickets', []))
+    tickets.request_tickets(context.GLOBAL.zk.conn,
+                            manifest['name'],
+                            tkts_spool_dir,
+                            principals)
 
 
 def sigterm_handler(_signo, _stack_frame):

--- a/lib/python/treadmill/sproc/restapi.py
+++ b/lib/python/treadmill/sproc/restapi.py
@@ -35,11 +35,12 @@ def init():
                   required=True, type=cli.LIST)
     @click.option('-c', '--cors-origin', help='CORS origin REGEX',
                   required=True)
-    @click.option('--workers', help='Number of workers',
-                  default=5)
+    @click.option('--workers', help='Number of workers', default=1)
+    @click.option('--backlog', help='Maximum ', default=128)
     @click.option('-A', '--authz', help='Authoriztion argument',
                   required=False)
-    def top(port, socket, auth, title, modules, cors_origin, workers, authz):
+    def top(port, socket, auth, title, modules, cors_origin, workers, backlog,
+            authz):
         """Run Treadmill API server."""
         context.GLOBAL.zk.add_listener(zkutils.exit_on_lost)
 
@@ -49,10 +50,13 @@ def init():
         if port:
             rest_server = rest.TcpRestServer(port, auth_type=auth,
                                              protect=api_paths,
-                                             workers=workers)
+                                             workers=workers,
+                                             backlog=backlog)
         # TODO: need to rename that - conflicts with import socket.
         elif socket:
-            rest_server = rest.UdsRestServer(socket, auth_type=auth)
+            rest_server = rest.UdsRestServer(socket, auth_type=auth,
+                                             workers=workers,
+                                             backlog=backlog)
         else:
             click.echo('port or socket must be specified')
             sys.exit(1)

--- a/lib/python/treadmill/sproc/service.py
+++ b/lib/python/treadmill/sproc/service.py
@@ -1,5 +1,5 @@
-"""Runs the Treadmill localdisk service."""
-
+"""Runs the Treadmill localdisk service.
+"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -13,8 +13,8 @@ import click
 
 from treadmill import appenv
 from treadmill import diskbenchmark
-from treadmill import fs
 from treadmill import localdiskutils
+from treadmill.fs import linux as fs_linux
 
 from .. import services
 
@@ -89,12 +89,16 @@ def init():
 
         # prepare block device
         if block_dev is not None:
-            underlying_device_uuid = fs.device_uuid(
+            underlying_device_uuid = fs_linux.device_uuid(
                 block_dev
             )
         else:
-            underlying_device_uuid = fs.device_uuid(
-                fs.maj_min_to_blk(*fs.path_to_maj_min(img_location))
+            underlying_device_uuid = fs_linux.blk_uuid(
+                fs_linux.maj_min_to_blk(
+                    *fs_linux.maj_min_from_path(
+                        img_location
+                    )
+                )
             )
             block_dev = localdiskutils.init_block_dev(
                 localdiskutils.TREADMILL_IMG,

--- a/lib/python/treadmill/syscall/mount.py
+++ b/lib/python/treadmill/syscall/mount.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import operator
 
 import ctypes
 from ctypes import (
@@ -17,6 +18,11 @@ from ctypes import (
     c_void_p,
 )
 from ctypes.util import find_library
+
+import enum
+import six
+
+from treadmill import utils
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,18 +53,19 @@ _MOUNT_DECL = ctypes.CFUNCTYPE(
 _MOUNT = _MOUNT_DECL(('mount', _LIBC))
 
 
-def mount(source, target, fs_type, mnt_flags=()):
-    """Mount ``source`` on ``target`` using filesystem type ``fs_type`` and
-    mount flags ``mnt_flags``.
-
-    NOTE: Mount data argument is not supported.
-    """
-    res = _MOUNT(source, target, fs_type, mnt_flags, 0)
+def _mount(source, target, fs_type, mnt_flags, data):
+    res = _MOUNT(source, target, fs_type, mnt_flags, data)
     if res < 0:
         errno = ctypes.get_errno()
         raise OSError(
             errno, os.strerror(errno),
-            'mount(%r, %r, %r, %r)' % (source, target, fs_type, mnt_flags)
+            'mount(%r, %r, %r, 0x%x, %r)' % (
+                source,
+                target,
+                fs_type,
+                mnt_flags,
+                data
+            )
         )
 
     return res
@@ -82,123 +89,227 @@ _UMOUNT2_DECL = ctypes.CFUNCTYPE(
 _UMOUNT2 = _UMOUNT2_DECL(('umount2', _LIBC))
 
 
-def umount(target, flags=None):
+def _umount(target):
     """Umount ``target``.
     """
-    res = 0
-    if flags is None:
-        res = _UMOUNT(target)
-        if res < 0:
-            errno = ctypes.get_errno()
-            raise OSError(
-                errno, os.strerror(errno),
-                'umount(%r)' % (target, )
-            )
+    res = _UMOUNT(target)
+    if res < 0:
+        errno = ctypes.get_errno()
+        raise OSError(
+            errno, os.strerror(errno),
+            'umount(%r)' % (target, )
+        )
 
-    else:
-        res = _UMOUNT2(target, flags)
-        if res < 0:
-            errno = ctypes.get_errno()
-            raise OSError(
-                errno, os.strerror(errno),
-                'umount2(%r, %r)' % (target, flags)
-            )
 
-    return res
+def _umount2(target, flags=None):
+    res = _UMOUNT2(target, flags)
+    if res < 0:
+        errno = ctypes.get_errno()
+        raise OSError(
+            errno, os.strerror(errno),
+            'umount2(%r, %r)' % (target, flags)
+        )
 
 
 ###############################################################################
 # NOTE: below values taken from mount kernel interface sys/mount.h
 
-# Mount flags
+class MSFlags(enum.IntEnum):
+    """All mount flags.
+    """
+    #: MS_MGC_VAL is a flag marker, needs to be included in all calls.
+    MGC_VAL = 0xC0ED0000
+
+    #: Mount read-only.
+    RDONLY = 0x000001
+    #: Ignore suid and sgid bits.
+    NOSUID = 0x000002
+    #: Disallow access to device special files.
+    NODEV = 0x000004
+    #: Disallow program execution.
+    NOEXEC = 0x000008
+    #: Writes are synced at once.
+    SYNCHRONOUS = 0x000010
+    #: Alter flags of a mounted FS.
+    REMOUNT = 0x000020
+    #: Allow mandatory locks on an FS.
+    MANDLOCK = 0x000040
+    #: Directory modifications are synchronous.
+    DIRSYNC = 0x000080
+    #: Do not update access times.
+    NOATIME = 0x000400
+    #: Do not update directory access times.
+    NODIRATIME = 0x000800
+    #: Bind a mount point to a different place .
+    BIND = 0x001000
+    #: Move a mount point to a different place .
+    MOVE = 0x002000
+    #: Recursively apply the UNBINDABLE, PRIVATE, SLAVE, or SHARED flags.
+    REC = 0x004000
+
+    # See https://www.kernel.org/doc/Documentation/filesystems/
+    #                                                       sharedsubtree.txt
+    #: unbindable mount
+    UNBINDABLE = 0x020000
+    #: private mount
+    PRIVATE = 0x040000
+    #: slave mount
+    SLAVE = 0x080000
+    #: shared mount
+    SHARED = 0x100000
+
+
+#: Mount flag marker.
+MS_MGC_VAL = MSFlags.MGC_VAL
 
 #: Mount read-only.
-MS_RDONLY = 1
-
+MS_RDONLY = MSFlags.RDONLY
 #: Ignore suid and sgid bits.
-MS_NOSUID = 2
-
+MS_NOSUID = MSFlags.NOSUID
 #: Disallow access to device special files.
-MS_NODEV = 4
-
+MS_NODEV = MSFlags.NODEV
 #: Disallow program execution.
-MS_NOEXEC = 8
-
+MS_NOEXEC = MSFlags.NOEXEC
 #: Writes are synced at once.
-MS_SYNCHRONOUS = 16
-
+MS_SYNCHRONOUS = MSFlags.SYNCHRONOUS
 #: Alter flags of a mounted FS.
-MS_REMOUNT = 32
-
+MS_REMOUNT = MSFlags.REMOUNT
 #: Allow mandatory locks on an FS.
-MS_MANDLOCK = 64
-
+MS_MANDLOCK = MSFlags.MANDLOCK
 #: Directory modifications are synchronous.
-MS_DIRSYNC = 128
-
+MS_DIRSYNC = MSFlags.DIRSYNC
 #: Do not update access times.
-MS_NOATIME = 1024
-
+MS_NOATIME = MSFlags.NOATIME
 #: Do not update directory access times.
-MS_NODIRATIME = 2048
-
+MS_NODIRATIME = MSFlags.NODIRATIME
 #: Bind a mount point to a different place .
-MS_BIND = 4096
-
+MS_BIND = MSFlags.BIND
 #: Move a mount point to a different place .
-MS_MOVE = 8192
-
+MS_MOVE = MSFlags.MOVE
 #: Recursively apply the UNBINDABLE, PRIVATE, SLAVE, or SHARED flags.
-MS_REC = 16384
+MS_REC = MSFlags.REC
 
 # See https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt
-
 #: unbindable mount
-MS_UNBINDABLE = 1 << 17
-
+MS_UNBINDABLE = MSFlags.UNBINDABLE
 #: private mount
-MS_PRIVATE = 1 << 18
-
+MS_PRIVATE = MSFlags.PRIVATE
 #: slave mount
-MS_SLAVE = 1 << 19
-
+MS_SLAVE = MSFlags.SLAVE
 #: shared mount
-MS_SHARED = 1 << 20
+MS_SHARED = MSFlags.SHARED
 
-# Umount2 operations flags
+
+class MNTFlags(enum.IntEnum):
+    """All umount2 operations flags.
+    """
+    #: Force unmounting
+    FORCE = 0x1
+    #: Just detach from the tree
+    DETACH = 0x2
+    #: Mark for expiry
+    EXPIRE = 0x4
+
 
 #: Force unmounting
-MNT_FORCE = 1
-
+MNT_FORCE = MNTFlags.FORCE
 #: Just detach from the tree
-MNT_DETACH = 2
-
+MNT_DETACH = MNTFlags.DETACH
 #: Mark for expiry
-MNT_EXPIRE = 4
+MNT_EXPIRE = MNTFlags.EXPIRE
 
 
 ###############################################################################
+# Main mount/umount functions
+
+def mount(source, target, fs_type, mnt_flags=(), mnt_opts=()):
+    """Mount ``source`` on ``target`` using filesystem type ``fs_type`` and
+    mount flags ``mnt_flags``.
+
+    NOTE: Mount data argument is not supported.
+
+    :params `str` source:
+        What to mount
+    :params `str` target:
+        Where to mount it
+    """
+    if source is not None:
+        source = source.encode()
+    if target is not None:
+        target = target.encode()
+    else:
+        target = source
+    if fs_type is not None:
+        fs_type = fs_type.encode()
+
+    # Fix up mount flags
+    mnt_flags = utils.get_iterable(mnt_flags)
+    flags = int(
+        six.moves.reduce(
+            operator.or_, mnt_flags, MS_MGC_VAL
+        )
+    )
+    # Fix up mount options
+    options = ','.join([
+        '%s=%s' % (key, value)
+        for (key, value) in six.iteritems(dict(mnt_opts))
+    ])
+    if options:
+        options = options.encode()
+    else:
+        options = None
+
+    _LOGGER.debug('mount(%r, %r, %r, %r, %r)',
+                  source, target, fs_type,
+                  utils.parse_mask(flags, MSFlags), options)
+
+    return _mount(source, target, fs_type, flags, options)
+
+
+def unmount(target, mnt_flags=()):
+    """Umount ``target``.
+    """
+    target = target.encode()
+
+    mnt_flags = utils.get_iterable(mnt_flags)
+    mnt_flags = six.moves.reduce(
+        operator.or_, mnt_flags, 0
+    )
+
+    _LOGGER.debug('umount(%r, %r)',
+                  target, utils.parse_mask(mnt_flags, MNTFlags))
+
+    if not mnt_flags:
+        return _umount(target)
+
+    else:
+        return _umount2(target, mnt_flags)
+
+
+###############################################################################
+
 __all__ = [
-    'MS_RDONLY',
-    'MS_NOSUID',
-    'MS_NODEV',
-    'MS_NOEXEC',
-    'MS_SYNCHRONOUS',
-    'MS_REMOUNT',
-    'MS_MANDLOCK',
-    'MS_DIRSYNC',
-    'MS_NOATIME',
-    'MS_NODIRATIME',
-    'MS_BIND',
-    'MS_MOVE',
-    'MS_REC',
-    'MS_UNBINDABLE',
-    'MS_PRIVATE',
-    'MS_SLAVE',
-    'MS_SHARED',
-    'MNT_FORCE',
     'MNT_DETACH',
     'MNT_EXPIRE',
+    'MNT_FORCE',
+    'MS_BIND',
+    'MS_DIRSYNC',
+    'MS_MANDLOCK',
+    'MS_MGC_VAL',
+    'MS_MOVE',
+    'MS_NOATIME',
+    'MS_NODEV',
+    'MS_NODIRATIME',
+    'MS_NOEXEC',
+    'MS_NOSUID',
+    'MS_PRIVATE',
+    'MS_RDONLY',
+    'MS_REC',
+    'MS_REMOUNT',
+    'MS_SHARED',
+    'MS_SLAVE',
+    'MS_SYNCHRONOUS',
+    'MS_UNBINDABLE',
     'mount',
-    'umount',
+    'unmount',
 ]

--- a/lib/python/treadmill/utils.py
+++ b/lib/python/treadmill/utils.py
@@ -764,3 +764,24 @@ def json_genencode(obj, indent=None):
         six.text_type(chunk)
         for chunk in encoder.iterencode(obj)
     )
+
+
+def parse_mask(value, mask_enum):
+    """Parse a mask into indivitual mask values from enum.
+
+    :params ``int`` value:
+        (Combined) mask value.
+    :params ``enum.IntEnum`` mask_enum:
+        Enum of all possible mask values.
+    :returns:
+        ``list`` - List of enum values and optional remainder.
+    """
+    masks = []
+    for mask in mask_enum:
+        if value & mask:
+            masks.append(mask.name)
+            value ^= mask
+    if value:
+        masks.append(hex(value))
+
+    return masks

--- a/lib/python/treadmill/websocket/__init__.py
+++ b/lib/python/treadmill/websocket/__init__.py
@@ -21,6 +21,7 @@ import os
 import sqlite3
 import threading
 import time
+import uuid
 
 import enum
 
@@ -47,6 +48,7 @@ def make_handler(pubsub):
             tornado.websocket.WebSocketHandler.__init__(
                 self, application, request, **kwargs
             )
+            self._request_id = str(uuid.uuid4())
             self._subscriptions = set()
 
         def active(self, sub_id=None):
@@ -64,7 +66,17 @@ def make_handler(pubsub):
 
             Override if you want to do something else besides log the action.
             """
-            _LOGGER.info('Connection opened.')
+            _LOGGER.info('[%s] Connection opened, remote ip: %s',
+                         self._request_id, self.request.remote_ip)
+
+        def send_msg(self, msg):
+            """Send message."""
+            _LOGGER.info('[%s] Sending message: %r', self._request_id, msg)
+            try:
+                self.write_message(msg)
+            except Exception:  # pylint: disable=W0703
+                _LOGGER.exception('[%s] Error sending message: %r',
+                                  self._request_id, msg)
 
         def send_error_msg(self, error_str, sub_id=None, close_conn=True):
             """Convenience method for logging and returning errors.
@@ -75,22 +87,21 @@ def make_handler(pubsub):
             Note: this method will close the connection after sending back the
             error, unless close_conn=False.
             """
-            _LOGGER.info(error_str)
-
             error_msg = {'_error': error_str,
                          'when': time.time()}
             if sub_id is not None:
                 error_msg['sub-id'] = sub_id
-                _LOGGER.info('Removing subscription %s', sub_id)
+                _LOGGER.info('[%s] Removing subscription %s',
+                             self._request_id, sub_id)
                 try:
                     self._subscriptions.remove(sub_id)
                 except KeyError:
                     pass
 
-            self.write_message(error_msg)
+            self.send_msg(error_msg)
 
             if close_conn:
-                _LOGGER.info('Closing connection.')
+                _LOGGER.info('[%s] Closing connection.', self._request_id)
                 self.close()
 
         def on_close(self):
@@ -98,7 +109,7 @@ def make_handler(pubsub):
 
             Override if you want to do something else besides log the action.
             """
-            _LOGGER.info('Connection closed.')
+            _LOGGER.info('[%s] Connection closed.', self._request_id)
 
         def check_origin(self, origin):
             """Overriding check_origin method from base class.
@@ -115,17 +126,20 @@ def make_handler(pubsub):
                 _LOGGER.fatal('pubsub is not configured, ignore.')
                 self.send_error_msg('Fatal: unexpected error', close_conn=True)
 
+            _LOGGER.info('[%s] Received message: %s',
+                         self._request_id, jmessage)
+
             sub_id = None
             close_conn = True
             try:
                 message = json.loads(jmessage)
-                _LOGGER.debug('message: %r', message)
 
                 sub_id = message.get('sub-id')
                 close_conn = sub_id is None
 
                 if message.get('unsubscribe') is True:
-                    _LOGGER.info('Unsubscribing %s', sub_id)
+                    _LOGGER.info('[%s] Unsubscribing %s',
+                                 self._request_id, sub_id)
                     try:
                         self._subscriptions.remove(sub_id)
                     except KeyError:
@@ -156,12 +170,14 @@ def make_handler(pubsub):
                 snapshot = message.get('snapshot', False)
 
                 if sub_id and not snapshot:
-                    _LOGGER.info('Adding subscription %s', sub_id)
+                    _LOGGER.info('[%s] Adding subscription %s',
+                                 self._request_id, sub_id)
                     self._subscriptions.add(sub_id)
 
                 for watch, pattern in subscription:
                     pubsub.register(watch, pattern, self, impl, since, sub_id)
                 if snapshot and close_conn:
+                    _LOGGER.info('[%s] Closing connection.', self._request_id)
                     self.close()
 
             except Exception as err:  # pylint: disable=W0703
@@ -279,20 +295,19 @@ class DirWatchPubSub(object):
         """Notify interested handlers of the change."""
         root_len = len(self.root)
 
-        for pattern, handler, impl, sub_id in handlers:
+        for _pattern, handler, impl, sub_id in handlers:
             try:
                 payload = impl.on_event(path[root_len:],
                                         operation,
                                         content)
                 if payload is not None:
-                    _LOGGER.debug('notify: %s, %s (%s)',
-                                  path, operation, pattern)
                     payload['when'] = when
                     if sub_id is not None:
                         payload['sub-id'] = sub_id
-                    handler.write_message(payload)
+                    handler.send_msg(payload)
             except Exception as err:  # pylint: disable=broad-except
-                _LOGGER.exception('Error handling event')
+                _LOGGER.exception('Error handling event: %s, %s, %s, %s, %s',
+                                  path, operation, content, when, sub_id)
                 handler.send_error_msg(
                     '{cls}: {err}'.format(
                         cls=type(err).__name__,
@@ -304,8 +319,16 @@ class DirWatchPubSub(object):
 
     def _db_records(self, db_path, sow_table, watch, pattern, since):
         """Get matching records from db."""
-        _LOGGER.info('Using sow db: %s, sow table: %s, watch: %s, pattern: %s',
-                     db_path, sow_table, watch, pattern)
+        # if file does not exist, do not try to open it. Opening connection
+        # will create the file, there is no way to prevent this from
+        # happening until py3.
+        #
+        if not os.path.exists(db_path):
+            _LOGGER.info('Ignore deleted db: %s', db_path)
+            return (None, None)
+
+        # There is rare condition that the db file is deleted HERE. In this
+        # case connection will be open, but the tables will not be there.
         conn = sqlite3.connect(db_path)
 
         # Before Python 3.7 GLOB pattern must not be parametrized to use index.
@@ -317,7 +340,16 @@ class DirWatchPubSub(object):
 
         # Return open connection, as conn.execute is cursor iterator, not
         # materialized list.
-        return conn, conn.execute(select_stmt, (watch, since,))
+        try:
+            return conn, conn.execute(select_stmt, (watch, since,))
+        except sqlite3.OperationalError as db_err:
+            # Not sure if the file needs to be deleted at this point. As
+            # sow_table is a parameter, passing non-existing table can cause
+            # legit file to be deleted.
+            _LOGGER.info('Unable to execute: select from %s:%s ..., %s',
+                         db_path, sow_table, str(db_err))
+            conn.close()
+            return (None, None)
 
     def _sow(self, watch, pattern, since, handler, impl, sub_id=None):
         """Publish state of the world."""
@@ -332,8 +364,10 @@ class DirWatchPubSub(object):
                     payload['when'] = when
                     if sub_id is not None:
                         payload['sub-id'] = sub_id
-                    handler.write_message(payload)
+                    handler.send_msg(payload)
             except Exception as err:  # pylint: disable=W0703
+                _LOGGER.exception('Error handling sow event: %s, %s, %s, %s',
+                                  path, content, when, sub_id)
                 handler.send_error_msg(str(err), sub_id=sub_id)
 
         db_connections = []
@@ -352,9 +386,14 @@ class DirWatchPubSub(object):
                     conn, db_cursor = self._db_records(
                         db, sow_table, watch, pattern, since
                     )
-                    records.append(db_cursor)
+                    if db_cursor:
+                        records.append(db_cursor)
+
                     # FIXME: Figure out pylint use before assign
-                    db_connections.append(conn)  # pylint: disable=E0601
+                    #
+                    # pylint: disable=E0601
+                    if conn:
+                        db_connections.append(conn)
 
             records.append(fs_records)
             # Merge db and fs records, removing duplicates.

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -641,11 +641,11 @@ class AllocationTest(unittest.TestCase):
         }
         self.assertEqual(ldap_entry, self.alloc.to_entry(obj))
 
-    @mock.patch('treadmill.admin.Admin.search', mock.Mock())
+    @mock.patch('treadmill.admin.Admin.paged_search', mock.Mock())
     @mock.patch('treadmill.admin.LdapObject.get', mock.Mock(return_value={}))
     def test_get(self):
         """Tests loading cell allocations."""
-        treadmill.admin.Admin.search.return_value = [
+        treadmill.admin.Admin.paged_search.return_value = [
             ('cell=xxx,allocation=prod1,...',
              {'cell': ['xxx'],
               'memory': ['1G'],
@@ -659,7 +659,7 @@ class AllocationTest(unittest.TestCase):
               'pattern;tm-alloc-assignment-345': ['ppp.ddd']})
         ]
         obj = self.alloc.get('foo:bar/prod1')
-        treadmill.admin.Admin.search.assert_called_with(
+        treadmill.admin.Admin.paged_search.assert_called_with(
             attributes=mock.ANY,
             search_base='allocation=prod1,tenant=bar,tenant=foo,'
                         'ou=allocations,ou=treadmill,dc=xx,dc=com',

--- a/tests/api/scheduler_test.py
+++ b/tests/api/scheduler_test.py
@@ -138,6 +138,36 @@ class ApiReportTest(unittest.TestCase):
             )
         )
 
+    @mock.patch('treadmill.context.GLOBAL', mock.Mock(cell='test'))
+    @mock.patch('treadmill.context.ZkContext.conn', mock.Mock)
+    @mock.patch('treadmill.scheduler.loader.Loader')
+    @mock.patch('treadmill.scheduler.zkbackend', mock.Mock)
+    def test_get_readonly_scheduler(self, loader_mock):
+        """Test the get_readonly_scheduler() func."""
+        # W0212(protected-access): Access to a protected member
+        # pylint: disable=W0212
+        # first invocation, _RO_SCHEDULER_INSTANCE is not yet initialized
+        now = scheduler._CACHE_TIMEOUT - 1
+        with mock.patch('time.time', return_value=now):
+            scheduler.get_readonly_scheduler()
+            self.assertTrue(loader_mock.called)
+            self.assertEqual(scheduler._LAST_CACHE_UPDATE, now)
+
+        # more than _CACHE_TIMEOUT time elapsed since last run
+        loader_mock.reset_mock()
+        now = now + scheduler._CACHE_TIMEOUT + 1
+        with mock.patch('time.time', return_value=now):
+            scheduler.get_readonly_scheduler()
+            self.assertTrue(loader_mock.called)
+            self.assertEqual(scheduler._LAST_CACHE_UPDATE, now)
+
+        # less than _CACHE_TIMEOUT time elapsed since last run
+        loader_mock.reset_mock()
+        now = now + scheduler._CACHE_TIMEOUT - 1
+        with mock.patch('time.time', return_value=now):
+            scheduler.get_readonly_scheduler()
+            self.assertFalse(loader_mock.called)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/appenv_test.py
+++ b/tests/appenv_test.py
@@ -43,7 +43,7 @@ class AppEnvTest(unittest.TestCase):
         if self.root and os.path.isdir(self.root):
             shutil.rmtree(self.root)
 
-    @unittest.skipUnless(sys.platform == 'linux2', 'Requires Linux')
+    @unittest.skipUnless(sys.platform.startswith('linux'), 'Requires Linux')
     @mock.patch('treadmill.iptables.initialize', mock.Mock())
     @mock.patch('treadmill.rulefile.RuleMgr.initialize', mock.Mock())
     @mock.patch('treadmill.runtime.linux.image.fs.init_plugins', mock.Mock())

--- a/tests/apptrace/zk_test.py
+++ b/tests/apptrace/zk_test.py
@@ -252,6 +252,7 @@ class AppTraceZKTest(mockzk.MockZookeeperTestCase):
     def test_finished_cleanup(self):
         """Tests tasks cleanup.
         """
+        data = b"{data: '1.0', host: foo, state: finished, when: '123.45'}\n"
         zk_content = {
             'trace': {
                 '0001': {
@@ -260,13 +261,20 @@ class AppTraceZKTest(mockzk.MockZookeeperTestCase):
                 },
             },
             'finished': {
-                'app1#0001': {'.metadata': {'last_modified': 1000}},
-                'app1#0002': {'.metadata': {'last_modified': 1000}},
-                'app1#0003': {'.metadata': {'last_modified': 1000}},
-                'app1#0004': {'.metadata': {'last_modified': 1000}},
-                'app1#0005': {'.metadata': {'last_modified': 1000}},
-                'app1#0006': {'.metadata': {'last_modified': 1000}},
-                'app1#0007': {'.metadata': {'last_modified': 1000}},
+                'app1#0001': {'.metadata': {'last_modified': 1000},
+                              '.data': data},
+                'app1#0002': {'.metadata': {'last_modified': 1000},
+                              '.data': data},
+                'app1#0003': {'.metadata': {'last_modified': 1000},
+                              '.data': data},
+                'app1#0004': {'.metadata': {'last_modified': 1000},
+                              '.data': data},
+                'app1#0005': {'.metadata': {'last_modified': 1000},
+                              '.data': data},
+                'app1#0006': {'.metadata': {'last_modified': 1000},
+                              '.data': data},
+                'app1#0007': {'.metadata': {'last_modified': 1000},
+                              '.data': data},
             },
             'trace.history': {
             },
@@ -299,15 +307,20 @@ class AppTraceZKTest(mockzk.MockZookeeperTestCase):
             ) VALUES(?, ?, ?, ?, ?)
             """,
             [
-                ('/finished/app1#0001', 1000.0, '{}\n',
+                ('/finished/app1#0001', 1000.0,
+                 "{data: '1.0', host: foo, state: finished, when: '123.45'}\n",
                  '/finished', 'app1#0001'),
-                ('/finished/app1#0002', 1000.0, '{}\n',
+                ('/finished/app1#0002', 1000.0,
+                 "{data: '1.0', host: foo, state: finished, when: '123.45'}\n",
                  '/finished', 'app1#0002'),
-                ('/finished/app1#0003', 1000.0, '{}\n',
+                ('/finished/app1#0003', 1000.0,
+                 "{data: '1.0', host: foo, state: finished, when: '123.45'}\n",
                  '/finished', 'app1#0003'),
-                ('/finished/app1#0004', 1000.0, '{}\n',
+                ('/finished/app1#0004', 1000.0,
+                 "{data: '1.0', host: foo, state: finished, when: '123.45'}\n",
                  '/finished', 'app1#0004'),
-                ('/finished/app1#0005', 1000.0, '{}\n',
+                ('/finished/app1#0005', 1000.0,
+                 "{data: '1.0', host: foo, state: finished, when: '123.45'}\n",
                  '/finished', 'app1#0005')
             ]
         )

--- a/tests/cgroup_engine_test.py
+++ b/tests/cgroup_engine_test.py
@@ -37,7 +37,7 @@ class CgroupReaderTest(unittest.TestCase):
         'treadmill.cgroups.get_mountpoint',
         mock.Mock(return_value='/cgroups'))
     @mock.patch(
-        'treadmill.fs.maj_min_to_blk',
+        'treadmill.fs.linux.maj_min_to_blk',
         mock.Mock(return_value='/dev/sda3'))
     @mock.patch(
         'treadmill.metrics.engine.CgroupReader._get_block_dev_version',

--- a/tests/cli/scheduler_test.py
+++ b/tests/cli/scheduler_test.py
@@ -281,6 +281,50 @@ class ReportTest(unittest.TestCase):
         self.assertIn('1002', result.output)
         self.assertIn('1003', result.output)
 
+    @mock.patch('treadmill.restclient.get',
+                mock.Mock(return_value=mock.MagicMock(requests.Response)))
+    @mock.patch('treadmill.context.Context.cell_api',
+                mock.Mock(return_value=['http://example.com']))
+    def test_explain(self):
+        """Test behaviour and output of the 'explain' subverb."""
+        restclient.get.return_value.json.return_value = {
+            'columns': [
+                'partition', 'traits', 'affinity', 'state', 'lifetime',
+                'memory', 'cpu', 'disk', 'name'
+            ],
+            'data': [
+                [
+                    'True', 'True', 'True', 'False', 'True', 'False', 'True',
+                    'False', 'host_1.ms.com'
+                ], [
+                    'True', 'True', 'True', 'True', 'True', 'False', 'True',
+                    'False', 'host_2.ms.com'
+                ]
+            ]
+        }
+
+        result = self.runner.invoke(
+            self.scheduler, ['--cell', 'TEST', 'explain', 'proid.app#123']
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        restclient.get.assert_called_with(
+            ['http://example.com'], '/scheduler/explain/proid.app%23123'
+        )
+
+        self.assertIn('host_1.ms.com', result.output)
+        self.assertIn('host_2.ms.com', result.output)
+        self.assertIn('X', result.output)
+
+        explain_mod = plugin_manager.load(
+            'treadmill.cli.scheduler',
+            'explain'
+        )
+        # W0212(protected-access)
+        # pylint: disable=W0212
+        auto_handled_excepts = [ex[0] for ex in explain_mod._EXCEPTIONS]
+        self.assertNotIn(restclient.AlreadyExistsError, auto_handled_excepts)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/dirwatcher_test.py
+++ b/tests/dirwatcher_test.py
@@ -70,7 +70,7 @@ class DirWatcherTest(unittest.TestCase):
             res,
         )
 
-    @unittest.skipUnless(sys.platform == 'linux2', 'Requires Linux')
+    @unittest.skipUnless(sys.platform.startswith('linux'), 'Requires Linux')
     @mock.patch('select.poll', mock.Mock())
     def test_signal(self):
         """Tests behavior when signalled during wait."""

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import io
 import os
 import shutil
+import sys
 import tarfile
 import tempfile
 import unittest
@@ -25,14 +26,16 @@ else:
     import subprocess  # pylint: disable=wrong-import-order
 
 import treadmill
-from treadmill import fs
+import treadmill.fs
+
+if sys.platform.startswith('linux'):
+    import treadmill.fs.linux
 
 
-# Pylint complains about long names for test functions.
-# pylint: disable=C0103
-class FsTest(unittest.TestCase):
-    """Tests for teadmill.fs."""
-
+@unittest.skipUnless(sys.platform.startswith('linux'), 'Requires Linux')
+class FsLinuxTest(unittest.TestCase):
+    """Tests for teadmill.fs.linux.
+    """
     def setUp(self):
         self.root = tempfile.mkdtemp()
 
@@ -40,102 +43,262 @@ class FsTest(unittest.TestCase):
         if self.root and os.path.isdir(self.root):
             shutil.rmtree(self.root)
 
-    @mock.patch('treadmill.subproc.check_call', mock.Mock())
+    @mock.patch('treadmill.syscall.mount.unmount', mock.Mock(spec_set=True))
+    def test_umount_filesystem(self):
+        """Test umount call.
+        """
+        treadmill.fs.linux.umount_filesystem('/foo')
+
+        treadmill.syscall.mount.unmount.assert_called_with(target='/foo')
+
+    @mock.patch('treadmill.syscall.mount.mount', mock.Mock(spec_set=True))
+    def test_mount_filesystem(self):
+        """Test mounting a filesystem.
+        """
+        treadmill.fs.linux.mount_filesystem('/some/dev', '/some/mnt', 'type')
+
+        treadmill.syscall.mount.mount.assert_called_with(
+            source='/some/dev',
+            target='/some/mnt',
+            fs_type='type',
+            mnt_flags=mock.ANY
+        )
+
+    @mock.patch('treadmill.syscall.mount.mount', mock.Mock(spec_set=True))
     def test_mount_bind_dir(self):
-        """Tests fs.mount_bind directory binding behavior"""
-        # test binding directory in /
+        """Tests bind mounting directory binding behavior
+        """
         container_dir = os.path.join(self.root, 'container')
         os.makedirs(container_dir)
-
-        # test binding directory in /
         foo_dir = os.path.join(self.root, 'foo')
         os.makedirs(foo_dir)
-        fs.mount_bind(container_dir, foo_dir)
-        treadmill.subproc.check_call.assert_called_with(
+
+        treadmill.fs.linux.mount_bind(container_dir, foo_dir)
+
+        container_foo_dir = os.path.join(container_dir, foo_dir[1:])
+        treadmill.syscall.mount.mount.assert_has_calls(
             [
-                'mount',
-                '-n',
-                '--rbind',
-                foo_dir,
-                os.path.join(container_dir, foo_dir[1:]),
+                mock.call(
+                    source=foo_dir,
+                    target=container_foo_dir,
+                    fs_type=None,
+                    mnt_flags=mock.ANY
+                ),
+                mock.call(
+                    source=None,
+                    target=container_foo_dir,
+                    fs_type=None,
+                    mnt_flags=mock.ANY
+                ),
             ]
         )
+        self.assertCountEqual(
+            treadmill.syscall.mount.mount.call_args_list[0][1]['mnt_flags'],
+            (
+                treadmill.syscall.mount.MS_REC,
+                treadmill.syscall.mount.MS_BIND,
+            ),
+            'Validate flags passed to first mount call'
+        )
+        self.assertCountEqual(
+            treadmill.syscall.mount.mount.call_args_list[1][1]['mnt_flags'],
+            (
+                treadmill.syscall.mount.MS_BIND,
+                treadmill.syscall.mount.MS_RDONLY,
+                treadmill.syscall.mount.MS_REMOUNT,
+            ),
+            'Validate flags passed to second mount call'
+        )
+        self.assertEqual(
+            treadmill.syscall.mount.mount.call_count, 2
+        )
         self.assertTrue(
-            os.path.isdir(os.path.join(container_dir, foo_dir[1:]))
+            os.path.isdir(container_foo_dir)
         )
-        treadmill.subproc.check_call.reset_mock()
 
-        # test binding directory with subdirs
-        bar_dir = os.path.join(self.root, 'bar')
-        os.makedirs(os.path.join(bar_dir, 'baz'))
-        fs.mount_bind(container_dir, bar_dir)
-        treadmill.subproc.check_call.assert_called_with(
-            [
-                'mount',
-                '-n',
-                '--rbind',
-                bar_dir,
-                os.path.join(container_dir, bar_dir[1:])
-            ]
-        )
-        self.assertTrue(
-            os.path.isdir(os.path.join(container_dir, bar_dir[1:]))
-        )
-        treadmill.subproc.check_call.reset_mock()
-
-    @mock.patch('treadmill.subproc.check_call', mock.Mock())
-    def test_mount_bind_file(self):
-        """Verifies correct mount options for files vs dirs."""
+    @mock.patch('treadmill.syscall.mount.mount', mock.Mock(spec_set=True))
+    def test_mount_bind_dir_readwrite(self):
+        """Tests bind mounting directory binding behavior (read/write)
+        """
         container_dir = os.path.join(self.root, 'container')
         os.makedirs(container_dir)
+        foo_dir = os.path.join(self.root, 'foo')
+        os.makedirs(foo_dir)
 
-        # test binding a file
+        treadmill.fs.linux.mount_bind(container_dir, foo_dir, read_only=False)
+
+        container_foo_dir = os.path.join(container_dir, foo_dir[1:])
+        treadmill.syscall.mount.mount.assert_has_calls(
+            [
+                mock.call(
+                    source=foo_dir,
+                    target=container_foo_dir,
+                    fs_type=None,
+                    mnt_flags=mock.ANY
+                ),
+            ]
+        )
+        self.assertCountEqual(
+            treadmill.syscall.mount.mount.call_args_list[0][1]['mnt_flags'],
+            (
+                treadmill.syscall.mount.MS_REC,
+                treadmill.syscall.mount.MS_BIND,
+            ),
+            'Validate flags passed to first mount call'
+        )
+        self.assertEqual(
+            treadmill.syscall.mount.mount.call_count, 1
+        )
+        self.assertTrue(
+            os.path.isdir(container_foo_dir)
+        )
+
+    @mock.patch('treadmill.syscall.mount.mount', mock.Mock(spec_set=True))
+    def test_mount_bind_file(self):
+        """Verifies correct mount options for files vs dirs.
+        """
+        container_dir = os.path.join(self.root, 'container')
+        os.makedirs(container_dir)
         foo_file = os.path.join(self.root, 'foo')
         with io.open(os.path.join(self.root, 'foo'), 'w'):
             pass
-        fs.mount_bind(container_dir, foo_file)
-        treadmill.subproc.check_call.assert_called_with(
+
+        treadmill.fs.linux.mount_bind(container_dir, foo_file)
+
+        container_foo_file = os.path.join(container_dir, foo_file[1:])
+        treadmill.syscall.mount.mount.assert_has_calls(
             [
-                'mount',
-                '-n',
-                '--bind',
-                foo_file,
-                os.path.join(container_dir, foo_file[1:])
+                mock.call(
+                    source=foo_file,
+                    target=container_foo_file,
+                    fs_type=None,
+                    mnt_flags=mock.ANY
+                ),
+                mock.call(
+                    source=None,
+                    target=container_foo_file,
+                    fs_type=None,
+                    mnt_flags=mock.ANY
+                ),
             ]
         )
-        self.assertTrue(
-            os.path.isfile(os.path.join(container_dir, foo_file[1:]))
+        self.assertCountEqual(
+            treadmill.syscall.mount.mount.call_args_list[0][1]['mnt_flags'],
+            (
+                treadmill.syscall.mount.MS_BIND,
+            ),
+            'Validate flags passed to first mount call'
         )
-        treadmill.subproc.check_call.reset_mock()
+        self.assertCountEqual(
+            treadmill.syscall.mount.mount.call_args_list[1][1]['mnt_flags'],
+            (
+                treadmill.syscall.mount.MS_BIND,
+                treadmill.syscall.mount.MS_RDONLY,
+                treadmill.syscall.mount.MS_REMOUNT,
+            ),
+            'Validate flags passed to second mount call'
+        )
+        self.assertEqual(
+            treadmill.syscall.mount.mount.call_count, 2
+        )
+        self.assertTrue(
+            os.path.isfile(container_foo_file)
+        )
 
-    @mock.patch('treadmill.subproc.check_call', mock.Mock())
+    @mock.patch('treadmill.syscall.mount.mount', mock.Mock(spec_set=True))
     def test_mount_bind_failures(self):
-        """Tests mount_bind behavior with invalid input."""
-        self.assertRaises(Exception, fs.mount_bind, 'no_such_root', '/bin')
-        self.assertRaises(Exception, fs.mount_bind, self.root, '/nosuchdir')
-        self.assertRaises(Exception, fs.mount_bind, self.root, './relative')
-        self.assertRaises(Exception, fs.mount_bind, self.root, 'relative')
+        """Tests mount_bind behavior with invalid input.
+        """
+        self.assertRaises(Exception,
+                          treadmill.fs.linux.mount_bind,
+                          'no_such_root', '/bin')
+        self.assertRaises(Exception,
+                          treadmill.fs.linux.mount_bind,
+                          self.root, '/nosuchdir')
+        self.assertRaises(Exception,
+                          treadmill.fs.linux.mount_bind,
+                          self.root, './relative')
+        self.assertRaises(Exception,
+                          treadmill.fs.linux.mount_bind,
+                          self.root, 'relative')
 
-    @mock.patch('treadmill.subproc.check_call', mock.Mock())
+    @mock.patch('treadmill.syscall.mount.mount', mock.Mock(spec_set=True))
+    def test_mount_proc(self):
+        """Test mounting of proc filesystem.
+        """
+        treadmill.fs.linux.mount_proc('/foo')
+
+        treadmill.syscall.mount.mount.assert_called_with(
+            source='proc',
+            target='/foo/proc',
+            fs_type='proc',
+        )
+
+    @mock.patch('treadmill.syscall.mount.mount', mock.Mock(spec_set=True))
+    def test_mount_sysfs(self):
+        """Test mounting of sysfs filesystem.
+        """
+        treadmill.fs.linux.mount_sysfs('/foo')
+
+        treadmill.syscall.mount.mount.assert_called_with(
+            source='sysfs',
+            target='/foo/sys',
+            fs_type='sysfs',
+            mnt_flags=mock.ANY
+        )
+        self.assertCountEqual(
+            treadmill.syscall.mount.mount.call_args_list[0][1]['mnt_flags'],
+            (
+                treadmill.syscall.mount.MS_RDONLY,
+            ),
+            'Validate flags passed to second mount call'
+        )
+
+    @mock.patch('treadmill.syscall.mount.mount', mock.Mock(spec_set=True))
     def test_mount_tmpfs(self):
-        """Tests behavior of mount_tmpfs."""
-        # Using absolute path to mount dir inside chroot
-        treadmill.fs.mount_tmpfs('/a/b', '/var/spool/tickets', '4M')
-        treadmill.subproc.check_call.assert_called_with(
-            ['mount', '-n', '-o', 'size=4M', '-t', 'tmpfs', 'tmpfs',
-             '/a/b/var/spool/tickets'])
+        """Tests behavior of mount tmpfs.
+        """
+        treadmill.fs.linux.mount_tmpfs('/foo', '/tmp', size='4M')
+        treadmill.syscall.mount.mount.assert_called_with(
+            source='tmpfs',
+            target='/foo/tmp',
+            fs_type='tmpfs',
+            mnt_flags=mock.ANY,
+            mnt_opts={'size': '4M'}
+        )
+        self.assertCountEqual(
+            treadmill.syscall.mount.mount.call_args_list[0][1]['mnt_flags'],
+            (
+                treadmill.syscall.mount.MS_NOATIME,
+                treadmill.syscall.mount.MS_NODIRATIME,
+            ),
+            'Validate flags passed to second mount call'
+        )
+        treadmill.syscall.mount.mount.reset_mock()
 
-        treadmill.subproc.check_call.reset()
-        # Using relative path to mount dir
-        treadmill.fs.mount_tmpfs('/a/b', 'var/spool/tickets', '2M')
-        treadmill.subproc.check_call.assert_called_with(
-            ['mount', '-n', '-o', 'size=2M', '-t', 'tmpfs', 'tmpfs',
-             '/a/b/var/spool/tickets'])
+        treadmill.fs.linux.mount_tmpfs('/foo', '/tmp2')
 
-    @mock.patch('treadmill.subproc.check_call', mock.Mock())
-    def test_create_filesystem(self):
-        """Test loopback filesystem creation"""
-        treadmill.fs.create_filesystem('/dev/myapp')
+        treadmill.syscall.mount.mount.assert_called_with(
+            source='tmpfs',
+            target='/foo/tmp2',
+            fs_type='tmpfs',
+            mnt_flags=mock.ANY,
+            mnt_opts={}
+        )
+        self.assertCountEqual(
+            treadmill.syscall.mount.mount.call_args_list[0][1]['mnt_flags'],
+            (
+                treadmill.syscall.mount.MS_NOATIME,
+                treadmill.syscall.mount.MS_NODIRATIME,
+            ),
+            'Validate flags passed to second mount call'
+        )
+
+    @mock.patch('treadmill.subproc.check_call', mock.Mock(spec_set=True))
+    def test_blk_fs_create(self):
+        """Test filesystem creation
+        """
+        treadmill.fs.linux.blk_fs_create('/dev/myapp')
         treadmill.subproc.check_call.assert_called_with(
             [
                 'mke2fs',
@@ -146,6 +309,74 @@ class FsTest(unittest.TestCase):
             ]
         )
 
+    @mock.patch('treadmill.subproc.check_output',
+                mock.Mock(spec_set=True,
+                          return_value="""
+Filesystem volume name:   /boot
+Last mounted on:          <not available>
+Filesystem UUID:          d19ecb0a-fa74-4be2-85f6-2e3a50901cd9
+Filesystem magic number:  0xEF53
+Filesystem revision #:    1 (dynamic)
+Filesystem OS type:       Linux
+Inode count:              65280
+Block count:              1
+Reserved block count:     2
+Free blocks:              3
+Block size:               1024
+Default directory hash:   half_md4
+Directory Hash Seed:      20c6af65-0208-4e71-99cb-d5532c02e3b8
+"""))
+    def test_blk_fs_info(self):
+        """Test fs.read_filesystem_info()."""
+        res = treadmill.fs.linux.blk_fs_info('/dev/treadmill/<uniq>')
+
+        self.assertEqual(res['block count'], '1')
+        self.assertEqual(res['reserved block count'], '2')
+        self.assertEqual(res['free blocks'], '3')
+        self.assertEqual(res['block size'], '1024')
+        treadmill.subproc.check_output.reset_mock()
+
+        treadmill.subproc.check_output.side_effect = (
+            subprocess.CalledProcessError(1, 'command', 'some error')
+        )
+
+        self.assertEqual(
+            treadmill.fs.linux.blk_fs_info('/dev/treadmill/<uniq>'),
+            {}
+        )
+
+    @mock.patch('glob.glob',
+                mock.Mock(spec_set=True,
+                          return_value=('/sys/class/block/sda2/dev',
+                                        '/sys/class/block/sda3/dev')))
+    @mock.patch('io.open', mock.mock_open())
+    def test_maj_min_to_blk(self):
+        """Tests fs.maj_min_to_blk()"""
+        io.open.return_value.read.side_effect = ['8:2\n', '8:3\n']
+
+        self.assertEqual(
+            treadmill.fs.linux.maj_min_to_blk(8, 3),
+            '/dev/sda3'
+        )
+        io.open.reset_mock()
+
+        io.open.return_value.read.side_effect = ['8:2\n', '8:3\n']
+
+        self.assertIsNone(
+            treadmill.fs.linux.maj_min_to_blk(1, 2)
+        )
+
+
+class FsTest(unittest.TestCase):
+    """Tests for teadmill.fs."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if self.root and os.path.isdir(self.root):
+            shutil.rmtree(self.root)
+
     def test_rm_safe(self):
         """Test safe rm/unlink."""
         test_file = os.path.join(self.root, 'rmsafe_test')
@@ -153,9 +384,9 @@ class FsTest(unittest.TestCase):
             pass
 
         self.assertTrue(os.path.isfile(test_file))
-        fs.rm_safe(test_file)
+        treadmill.fs.rm_safe(test_file)
         self.assertFalse(os.path.exists(test_file))
-        fs.rm_safe(test_file)
+        treadmill.fs.rm_safe(test_file)
         self.assertFalse(os.path.exists(test_file))
 
     def test_rmtree_safe(self):
@@ -164,9 +395,9 @@ class FsTest(unittest.TestCase):
         os.mkdir(test_dir)
 
         self.assertTrue(os.path.isdir(test_dir))
-        fs.rmtree_safe(test_dir)
+        treadmill.fs.rmtree_safe(test_dir)
         self.assertFalse(os.path.exists(test_dir))
-        fs.rmtree_safe(test_dir)
+        treadmill.fs.rmtree_safe(test_dir)
         self.assertFalse(os.path.exists(test_dir))
 
     def test_tar_basic(self):
@@ -192,7 +423,7 @@ class FsTest(unittest.TestCase):
             pass
 
         self.assertEqual(
-            fs.tar(archive, tardir).name,
+            treadmill.fs.tar(archive, tardir).name,
             archive,
             'fs.tar runs successfully'
         )
@@ -202,13 +433,13 @@ class FsTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            fs.tar(archive, tardir2).name,
+            treadmill.fs.tar(archive, tardir2).name,
             archive,
             'fs.tar will succeed if tarfile already exists'
         )
 
         self.assertEqual(
-            fs.tar(archive, tardir, compression='gzip').name,
+            treadmill.fs.tar(archive, tardir, compression='gzip').name,
             '%s.gz' % archive,
             'fs.tar with gzip runs successfully'
         )
@@ -241,7 +472,10 @@ class FsTest(unittest.TestCase):
             pass
 
         self.assertEqual(
-            fs.tar(archive, [tardir, tardir2], compression='gzip').name,
+            treadmill.fs.tar(
+                archive, [tardir, tardir2],
+                compression='gzip'
+            ).name,
             '%s.gz' % archive,
             'fs.tar runs successfully'
         )
@@ -270,8 +504,8 @@ class FsTest(unittest.TestCase):
             pass
 
         fileobj = tempfile.TemporaryFile()
-        fs.tar(target=fileobj, sources=[tardir, tardir2],
-               compression='gzip')
+        treadmill.fs.tar(target=fileobj, sources=[tardir, tardir2],
+                         compression='gzip')
 
         # seek fileobj and check content
         fileobj.seek(0)
@@ -280,56 +514,6 @@ class FsTest(unittest.TestCase):
         self.assertTrue(
             'subdir' in names and 'file' in names and 'file2' in names
         )
-
-    @mock.patch('treadmill.subproc.check_output',
-                mock.Mock(return_value="""
-Filesystem volume name:   /boot
-Last mounted on:          <not available>
-Filesystem UUID:          d19ecb0a-fa74-4be2-85f6-2e3a50901cd9
-Filesystem magic number:  0xEF53
-Filesystem revision #:    1 (dynamic)
-Filesystem OS type:       Linux
-Inode count:              65280
-Block count:              1
-Reserved block count:     2
-Free blocks:              3
-Block size:               1024
-Default directory hash:   half_md4
-Directory Hash Seed:      20c6af65-0208-4e71-99cb-d5532c02e3b8
-"""))
-    def test_read_filesystem_info(self):
-        """Test fs.read_filesystem_info()."""
-        res = fs.read_filesystem_info('/dev/treadmill/<uniq>')
-
-        self.assertEqual(res['block count'], '1')
-        self.assertEqual(res['reserved block count'], '2')
-        self.assertEqual(res['free blocks'], '3')
-        self.assertEqual(res['block size'], '1024')
-
-        with mock.patch('treadmill.subproc.check_output',
-                        side_effect=subprocess.CalledProcessError(
-                            1, 'command', 'some error')):
-
-            self.assertEqual(fs.read_filesystem_info('/dev/treadmill/<uniq>'),
-                             {})
-
-    @mock.patch('io.open', mock.mock_open())
-    @mock.patch('glob.glob',
-                mock.Mock(return_value=('/sys/class/block/sda2/dev',
-                                        '/sys/class/block/sda3/dev')))
-    def test_maj_min_to_blk(self):
-        """Tests fs.maj_min_to_blk()"""
-        io.open.return_value.read.side_effect = ['8:2\n', '8:3\n']
-
-        self.assertEqual(
-            fs.maj_min_to_blk(8, 3),
-            '/dev/sda3'
-        )
-
-        io.open.reset_mock()
-        io.open.return_value.read.side_effect = ['8:2\n', '8:3\n']
-
-        self.assertIsNone(fs.maj_min_to_blk(-1, -2))
 
 
 if __name__ == '__main__':

--- a/tests/logcontext_test.py
+++ b/tests/logcontext_test.py
@@ -74,5 +74,18 @@ class ContainerAdapterTest(unittest.TestCase):
             'proid.app-name#appid uniqid')
 
 
+class LogContextTest(unittest.TestCase):
+    """Unit test for the LogContext class
+    """
+
+    def test_nested_adapters(self):
+        """Test whether adapters can be "nested"."""
+        with lc.LogContext(logging.getLogger(__name__),
+                           'proid.app#123') as outer:
+            outer.info('foo')
+            with lc.LogContext(outer, 'some.ting#123') as inner:
+                inner.info('bar')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -151,7 +151,7 @@ class MetricsTest(unittest.TestCase):
              'memory.soft_limit_in_bytes': 2,
              'memory.usage_in_bytes': 2})
 
-    @mock.patch('treadmill.fs.read_filesystem_info',
+    @mock.patch('treadmill.fs.linux.blk_fs_info',
                 mock.Mock(return_value={'block count': '2000',
                                         'free blocks': '1000',
                                         'block size': '1024'}))

--- a/tests/rest/api/scheduler_test.py
+++ b/tests/rest/api/scheduler_test.py
@@ -83,6 +83,15 @@ class ReportTest(unittest.TestCase):
             'servers', match=None, partition='part1'
         )
 
+    def test_get_explain(self):
+        """Test GET on /scheduler/explain path."""
+        self.impl.explain.get.return_value = pd.DataFrame(
+            [['host.ms.com', True, True, False]],
+            columns=['name', 'disk', 'cpu', 'mem']
+        )
+        self.client.get('/scheduler/explain/proid.app#123')
+        self.impl.explain.get.assert_called_with('proid.app#123')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/runtime/linux/image/native_test.py
+++ b/tests/runtime/linux/image/native_test.py
@@ -84,15 +84,14 @@ class NativeImageTest(unittest.TestCase):
         if self.container_dir and os.path.isdir(self.container_dir):
             shutil.rmtree(self.container_dir)
 
-    @mock.patch('pwd.getpwnam', mock.Mock(
-        return_value=collections.namedtuple('pwnam', 'pw_uid pw_gid')(42, 42)
-    ))
-    @mock.patch('os.chown', mock.Mock())
-    @mock.patch('treadmill.fs.mount_bind', mock.Mock())
-    @mock.patch('treadmill.fs.mount_tmpfs', mock.Mock())
+    @mock.patch('os.chown', mock.Mock(spec_set=True))
+    @mock.patch('treadmill.fs.linux.mount_bind', mock.Mock(spec_set=True))
+    @mock.patch('treadmill.fs.linux.mount_tmpfs', mock.Mock(spec_set=True))
+    @mock.patch('treadmill.fs.linux.mount_proc', mock.Mock(spec_set=True))
+    @mock.patch('treadmill.fs.linux.mount_sysfs', mock.Mock(spec_set=True))
     def test_make_fsroot(self):
         """Validates directory layout in chrooted environment."""
-        native.make_fsroot(self.root, 'myproid')
+        native.make_fsroot(self.root)
 
         def isdir(path):
             """Checks directory presence in chrooted environment."""
@@ -103,34 +102,30 @@ class NativeImageTest(unittest.TestCase):
             statinfo = os.stat(os.path.join(self.root, path))
             return statinfo.st_mode & stat.S_ISVTX
 
-        self.assertTrue(isdir('tmp'))
-        self.assertTrue(isdir('opt'))
-        self.assertTrue(isdir('var/spool/keytabs'))
-        self.assertTrue(isdir('var/spool/tickets'))
-        self.assertTrue(isdir('var/spool/tokens'))
-        self.assertTrue(isdir('var/tmp'))
-        self.assertTrue(isdir('var/tmp/cores'))
         self.assertTrue(isdir('home'))
+        self.assertTrue(isdir('opt'))
+        self.assertTrue(isdir('run'))
+        self.assertTrue(isdir('tmp'))
+        self.assertTrue(isdir('var/spool'))
+        self.assertTrue(isdir('var/tmp'))
 
-        self.assertTrue(issticky('tmp'))
         self.assertTrue(issticky('opt'))
+        self.assertTrue(issticky('run'))
+        self.assertTrue(issticky('tmp'))
         self.assertTrue(issticky('var/tmp'))
-        self.assertTrue(issticky('var/tmp/cores'))
-        self.assertTrue(issticky('var/spool/tickets'))
 
-        treadmill.fs.mount_tmpfs.assert_has_calls([
-            mock.call(mock.ANY, '/var/spool/tickets', mock.ANY),
-            mock.call(mock.ANY, '/var/spool/keytabs', mock.ANY)
-        ])
+        treadmill.fs.linux.mount_tmpfs.assert_called_once_with(
+            mock.ANY, '/run'
+        )
 
-        treadmill.fs.mount_bind.assert_has_calls([
-            mock.call(mock.ANY, '/bin', remount_opts=['ro'])
+        treadmill.fs.linux.mount_bind.assert_has_calls([
+            mock.call(mock.ANY, '/bin', read_only=True, recursive=True)
         ])
 
     @mock.patch('treadmill.cgroups.makepath',
                 mock.Mock(return_value='/test/cgroup/path'))
     @mock.patch('treadmill.fs.mkdir_safe', mock.Mock())
-    @mock.patch('treadmill.fs.mount_bind', mock.Mock())
+    @mock.patch('treadmill.fs.linux.mount_bind', mock.Mock())
     def test__share_cgroup_info(self):
         """Test sharing of cgroup information with the container."""
         # Access protected module _share_cgroup_info
@@ -141,8 +136,10 @@ class NativeImageTest(unittest.TestCase):
         treadmill.fs.mkdir_safe.assert_has_calls([
             mock.call('/some/root_dir/cgroup/memory')
         ])
-        treadmill.fs.mount_bind.assert_has_calls([
-            mock.call('/some/root_dir', '/cgroup/memory', '/test/cgroup/path')
+        treadmill.fs.linux.mount_bind.assert_has_calls([
+            mock.call('/some/root_dir', '/cgroup/memory',
+                      source='/test/cgroup/path',
+                      read_only=False, recursive=True)
         ])
 
     @mock.patch('pwd.getpwnam', mock.Mock(
@@ -151,7 +148,7 @@ class NativeImageTest(unittest.TestCase):
             ['pw_uid', 'pw_dir', 'pw_shell']
         )(3, '/', '/bin/sh')))
     @mock.patch('treadmill.fs.mkdir_safe', mock.Mock())
-    @mock.patch('treadmill.fs.mount_bind', mock.Mock())
+    @mock.patch('treadmill.fs.linux.mount_bind', mock.Mock())
     @mock.patch('treadmill.supervisor.create_service', mock.Mock())
     @mock.patch('treadmill.supervisor.create_scan_dir', mock.Mock())
     @mock.patch('treadmill.utils.create_script', mock.Mock())
@@ -318,9 +315,10 @@ class NativeImageTest(unittest.TestCase):
 
         self.assertEqual(2, mock_service_dir.write.call_count)
 
-        treadmill.fs.mount_bind.assert_called_with(
+        treadmill.fs.linux.mount_bind.assert_called_with(
             '/test_treadmill', '/services',
-            bind_opt='--bind', target='/some/dir/services'
+            source='/some/dir/services',
+            read_only=False, recursive=False
         )
 
     @mock.patch('treadmill.subproc.resolve', mock.Mock())
@@ -334,9 +332,9 @@ class NativeImageTest(unittest.TestCase):
 
         native._prepare_ldpreload(self.container_dir, self.app)
 
-        newfile = io.open(os.path.join(
-            self.container_dir, 'overlay', 'etc', 'ld.so.preload'
-        )).readlines()
+        with io.open(os.path.join(self.container_dir,
+                                  'overlay', 'etc', 'ld.so.preload')) as f:
+            newfile = f.readlines()
         self.assertEqual('/foo/1.so\n', newfile[-1])
 
     @mock.patch('pwd.getpwnam', mock.Mock(
@@ -352,7 +350,7 @@ class NativeImageTest(unittest.TestCase):
         native._prepare_hosts(self.container_dir, self.app)
 
         etc_dir = os.path.join(self.container_dir, 'overlay', 'etc')
-        run_dir = os.path.join(self.container_dir, 'overlay', 'var', 'run')
+        run_dir = os.path.join(self.container_dir, 'overlay', 'run')
 
         shutil.copyfile.assert_has_calls(
             [
@@ -399,42 +397,42 @@ class NativeImageTest(unittest.TestCase):
                       os.path.join(etc_dir, 'resolv.conf'))
         ])
 
-    @mock.patch('treadmill.fs.mount_bind', mock.Mock())
-    def test__bind_etc_overlay(self):
-        """Test binding etc overlay."""
-        # access protected module _bind_etc_overlay
+    @mock.patch('treadmill.fs.linux.mount_bind', mock.Mock())
+    def test__bind_overlay(self):
+        """Test binding overlay."""
+        # access protected module _bind_overlay
         # pylint: disable=w0212
-        native._bind_etc_overlay(self.container_dir, self.root)
+        native._bind_overlay(self.container_dir, self.root)
 
         overlay_dir = os.path.join(self.container_dir, 'overlay')
 
-        treadmill.fs.mount_bind.assert_has_calls(
+        treadmill.fs.linux.mount_bind.assert_has_calls(
             [
                 mock.call(self.root, '/etc/hosts',
-                          target=os.path.join(overlay_dir, 'etc/hosts'),
-                          bind_opt='--bind'),
-                mock.call(self.root, '/var/run/host-aliases',
-                          target=os.path.join(
-                              overlay_dir, 'var/run/host-aliases'
+                          source=os.path.join(overlay_dir, 'etc', 'hosts'),
+                          read_only=True, recursive=False),
+                mock.call(self.root, '/run/host-aliases',
+                          source=os.path.join(
+                              overlay_dir, 'run', 'host-aliases'
                           ),
-                          bind_opt='--bind'),
+                          read_only=False, recursive=False),
                 mock.call(self.root, '/etc/ld.so.preload',
-                          target=os.path.join(
+                          source=os.path.join(
                               overlay_dir, 'etc/ld.so.preload'
                           ),
-                          bind_opt='--bind'),
+                          read_only=True, recursive=False),
                 mock.call(self.root, '/etc/pam.d/sshd',
-                          target=os.path.join(overlay_dir, 'etc/pam.d/sshd'),
-                          bind_opt='--bind'),
+                          source=os.path.join(overlay_dir, 'etc/pam.d/sshd'),
+                          read_only=True, recursive=False),
                 mock.call(self.root, '/etc/resolv.conf',
-                          target=os.path.join(overlay_dir, 'etc/resolv.conf'),
-                          bind_opt='--bind'),
+                          source=os.path.join(overlay_dir, 'etc/resolv.conf'),
+                          read_only=True, recursive=False),
                 mock.call(self.root, '/etc/krb5.keytab',
-                          target=os.path.join(overlay_dir, 'etc/krb5.keytab'),
-                          bind_opt='--bind'),
+                          source=os.path.join(overlay_dir, 'etc/krb5.keytab'),
+                          read_only=True, recursive=False),
                 mock.call('/', '/etc/resolv.conf',
-                          target=os.path.join(overlay_dir, 'etc/resolv.conf'),
-                          bind_opt='--bind')
+                          source=os.path.join(overlay_dir, 'etc/resolv.conf'),
+                          read_only=True, recursive=False)
             ],
             any_order=True
         )

--- a/tests/runtime/linux/run_test.py
+++ b/tests/runtime/linux/run_test.py
@@ -62,11 +62,12 @@ class LinuxRuntimeRunTest(unittest.TestCase):
 
     @mock.patch('pwd.getpwnam', mock.Mock())
     @mock.patch('os.chown', mock.Mock())
-    @mock.patch('treadmill.fs.create_filesystem', mock.Mock())
-    @mock.patch('treadmill.fs.test_filesystem', mock.Mock(return_value=False))
+    @mock.patch('treadmill.fs.linux.blk_fs_create', mock.Mock())
+    @mock.patch('treadmill.fs.linux.blk_fs_test',
+                mock.Mock(return_value=False))
+    @mock.patch('treadmill.fs.linux.mount_bind', mock.Mock())
+    @mock.patch('treadmill.fs.linux.mount_filesystem', mock.Mock())
     @mock.patch('treadmill.fs.mkdir_safe', mock.Mock())
-    @mock.patch('treadmill.fs.mount_bind', mock.Mock())
-    @mock.patch('treadmill.fs.mount_filesystem', mock.Mock())
     @mock.patch('treadmill.subproc.check_call', mock.Mock())
     @mock.patch('treadmill.utils.rootdir',
                 mock.Mock(return_value='/test_treadmill'))
@@ -94,9 +95,9 @@ class LinuxRuntimeRunTest(unittest.TestCase):
         treadmill.runtime.linux._run._create_root_dir(container_dir,
                                                       localdisk)
 
-        treadmill.fs.create_filesystem.assert_called_with('/dev/foo')
+        treadmill.fs.linux.blk_fs_create.assert_called_with('/dev/foo')
         unshare.unshare.assert_called_with(unshare.CLONE_NEWNS)
-        treadmill.fs.mount_filesystem('/dev/foo', '/some/root_dir')
+        treadmill.fs.linux.mount_filesystem('/dev/foo', '/some/root_dir')
 
     @mock.patch('treadmill.cgroups.join', mock.Mock())
     def test_apply_cgroup_limits(self):
@@ -381,7 +382,7 @@ class LinuxRuntimeRunTest(unittest.TestCase):
     @mock.patch('treadmill.runtime.linux._run._unshare_network', mock.Mock())
     @mock.patch('treadmill.runtime.linux._run._apply_cgroup_limits',
                 mock.Mock())
-    @mock.patch('treadmill.fs.mount_bind', mock.Mock())
+    @mock.patch('treadmill.fs.linux.mount_bind', mock.Mock())
     @mock.patch('treadmill.runtime.linux.image.get_image_repo', mock.Mock())
     @mock.patch('treadmill.apphook.configure', mock.Mock())
     @mock.patch('treadmill.subproc.exec_pid1', mock.Mock())
@@ -543,7 +544,7 @@ class LinuxRuntimeRunTest(unittest.TestCase):
     @mock.patch('treadmill.runtime.linux._run._apply_cgroup_limits',
                 mock.Mock())
     @mock.patch('treadmill.runtime.linux.image.get_image_repo', mock.Mock())
-    @mock.patch('treadmill.fs.mount_bind', mock.Mock())
+    @mock.patch('treadmill.fs.linux.mount_bind', mock.Mock())
     @mock.patch('treadmill.apphook.configure', mock.Mock())
     @mock.patch('treadmill.subproc.exec_pid1', mock.Mock())
     @mock.patch('treadmill.subproc.check_call', mock.Mock())
@@ -632,7 +633,7 @@ class LinuxRuntimeRunTest(unittest.TestCase):
     @mock.patch('treadmill.runtime.linux._run._apply_cgroup_limits',
                 mock.Mock())
     @mock.patch('treadmill.runtime.linux.image.get_image_repo', mock.Mock())
-    @mock.patch('treadmill.fs.mount_bind', mock.Mock())
+    @mock.patch('treadmill.fs.linux.mount_bind', mock.Mock())
     @mock.patch('treadmill.apphook.configure', mock.Mock())
     @mock.patch('treadmill.subproc.exec_pid1', mock.Mock())
     @mock.patch('treadmill.subproc.check_call', mock.Mock())

--- a/tests/services/localdisk_service_test.py
+++ b/tests/services/localdisk_service_test.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import collections
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -28,6 +29,7 @@ from treadmill import localdiskutils
 from treadmill.services import localdisk_service
 
 
+@unittest.skipUnless(sys.platform.startswith('linux'), 'Requires Linux')
 class LocalDiskServiceTest(unittest.TestCase):
     """Unit tests for the local disk service implementation.
     """
@@ -92,7 +94,7 @@ class LocalDiskServiceTest(unittest.TestCase):
 
     @mock.patch('treadmill.cgroups.create', mock.Mock())
     @mock.patch('treadmill.cgroups.set_value', mock.Mock())
-    @mock.patch('treadmill.fs.create_filesystem', mock.Mock())
+    @mock.patch('treadmill.fs.linux.blk_fs_create', mock.Mock())
     @mock.patch('treadmill.lvm.lvcreate', mock.Mock())
     @mock.patch('treadmill.lvm.lvdisplay', mock.Mock())
     @mock.patch('treadmill.localdiskutils.refresh_vg_status',
@@ -172,7 +174,7 @@ class LocalDiskServiceTest(unittest.TestCase):
 
     @mock.patch('treadmill.cgroups.create', mock.Mock())
     @mock.patch('treadmill.cgroups.set_value', mock.Mock())
-    @mock.patch('treadmill.fs.create_filesystem', mock.Mock())
+    @mock.patch('treadmill.fs.linux.blk_fs_create', mock.Mock())
     @mock.patch('treadmill.lvm.lvcreate', mock.Mock())
     @mock.patch('treadmill.lvm.lvdisplay', mock.Mock())
     @mock.patch('treadmill.localdiskutils.refresh_vg_status',
@@ -211,7 +213,7 @@ class LocalDiskServiceTest(unittest.TestCase):
         # Reset all mocks
         treadmill.cgroups.create.reset_mock()
         treadmill.cgroups.set_value.reset_mock()
-        treadmill.fs.create_filesystem.reset_mock()
+        treadmill.fs.linux.blk_fs_create.reset_mock()
         treadmill.lvm.lvcreate.reset_mock()
         treadmill.lvm.lvdisplay.reset_mock()
         treadmill.localdiskutils.refresh_vg_status.reset_mock()

--- a/tests/spawn/manifest_watch_test.py
+++ b/tests/spawn/manifest_watch_test.py
@@ -57,7 +57,7 @@ class ManifestWatchTest(unittest.TestCase):
 
         watch._create_instance('test.yml')
 
-        self.assertEqual(3, treadmill.fs.mkdir_safe.call_count)
+        self.assertEqual(4, treadmill.fs.mkdir_safe.call_count)
         self.assertEqual(2, treadmill.utils.create_script.call_count)
         self.assertEqual(1, treadmill.fs.symlink_safe.call_count)
         io.open.assert_has_calls(

--- a/tests/tickets_test.py
+++ b/tests/tickets_test.py
@@ -41,8 +41,8 @@ class TicketLockerTest(unittest.TestCase):
                 mock.Mock())
     @mock.patch('treadmill.gssapiprotocol.GSSAPILineClient.write', mock.Mock())
     @mock.patch('treadmill.gssapiprotocol.GSSAPILineClient.read', mock.Mock())
-    @mock.patch('pwd.getpwnam', mock.Mock(
-        return_value=collections.namedtuple('pwnam', ['pw_uid'])(3)))
+    @mock.patch('treadmill.tickets.Ticket.copy', mock.Mock(spec_set=True))
+    @mock.patch('treadmill.tickets.Ticket.write', mock.Mock(spec_set=True))
     def test_request_tickets(self):
         """Test parsing output of request_tickets."""
         treadmill.zkutils.connect.return_value = kazoo.client.KazooClient()
@@ -54,9 +54,17 @@ class TicketLockerTest(unittest.TestCase):
         treadmill.gssapiprotocol.GSSAPILineClient.read.side_effect = (
             lambda: lines.pop(0))
 
-        reply = tickets.request_tickets(kazoo.client.KazooClient(), 'myapp')
+        tickets.request_tickets(
+            kazoo.client.KazooClient(),
+            'myapp',
+            self.tkt_dir,
+            set(['foo@bar'])
+        )
 
-        self.assertEqual([tickets.Ticket('foo@bar', b'abcd')], reply)
+        tickets.Ticket.write.assert_called_with()
+        tickets.Ticket.copy.assert_called_with(
+            os.path.join(self.tkt_dir, 'foo@bar')
+        )
 
     @mock.patch('kazoo.client.KazooClient.exists',
                 mock.Mock(return_value=True))
@@ -141,19 +149,64 @@ class TicketLockerTest(unittest.TestCase):
             os.path.join(self.tkt_dir, 'x@r1'))
         zkutils.ensure_deleted.assert_called_with(mock.ANY, '/tickets/x@r1/h')
 
-    @mock.patch('os.chown', mock.Mock())
-    @mock.patch('treadmill.tickets.krbcc_ok', mock.Mock())
-    def test_ticket_write(self):
-        """Tests writing ticket to the file system."""
+    @mock.patch('os.fchown', mock.Mock(spec_set=True))
+    @mock.patch('pwd.getpwnam', mock.Mock(
+        spec_set=True,
+        return_value=collections.namedtuple('pwnam', ['pw_uid'])(3)))
+    @mock.patch('treadmill.fs.rm_safe', mock.Mock(spec_set=True))
+    @mock.patch('treadmill.tickets.krbcc_ok', mock.Mock(spec_set=True))
+    def test_ticket_write_expired(self):
+        """Tests expiration checking of ticket before writing to the file
+        system.
+        """
         tkt = tickets.Ticket('uid@realm', b'content')
         tkt_path = os.path.join(self.tkt_dir, 'x')
         tickets.krbcc_ok.return_value = False
         tkt.write(tkt_path)
         self.assertFalse(os.path.exists(tkt_path))
+        treadmill.fs.rm_safe.assert_called_with(mock.ANY)
 
-        tickets.krbcc_ok.return_value = True
-        tkt.write(tkt_path)
-        self.assertTrue(os.path.exists(tkt_path))
+    @mock.patch('os.fchown', mock.Mock(spec_set=True))
+    @mock.patch('pwd.getpwnam', mock.Mock(
+        spec_set=True,
+        return_value=collections.namedtuple('pwnam', ['pw_uid'])(3)))
+    @mock.patch('treadmill.fs.rm_safe', mock.Mock(spec_set=True))
+    @mock.patch('treadmill.tickets.krbcc_ok',
+                mock.Mock(spec_set=True, return_value=True))
+    def test_ticket_write(self):
+        """Tests writing ticket to the file system.
+        """
+        tkt = tickets.Ticket('uid@realm', b'content')
+        test_tkt_path = '/tmp/krb5cc_%d' % 3
+
+        self.assertEqual(
+            tkt.tkt_path,
+            test_tkt_path
+        )
+        tkt.write()
+
+        self.assertTrue(os.path.exists(test_tkt_path))
+        treadmill.fs.rm_safe.assert_called_with(mock.ANY)
+
+    @mock.patch('os.fchown', mock.Mock(spec_set=True))
+    @mock.patch('pwd.getpwnam', mock.Mock(
+        spec_set=True,
+        return_value=collections.namedtuple('pwnam', ['pw_uid'])(3)))
+    @mock.patch('treadmill.fs.rm_safe', mock.Mock(spec_set=True))
+    def test_ticket_copy(self):
+        """Test copying tickets.
+        """
+        tkt = tickets.Ticket('uid@realm', b'content')
+        test_tkt_path = os.path.join(self.tkt_dir, 'foo')
+        # touch a ticket
+        with io.open(tkt.tkt_path, 'wb'):
+            pass
+
+        tkt.copy(dst=test_tkt_path)
+
+        self.assertTrue(os.path.exists(test_tkt_path))
+        os.fchown.assert_called_with(mock.ANY, 3, -1)
+        treadmill.fs.rm_safe.assert_called_with(mock.ANY)
 
 
 if __name__ == '__main__':

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -124,20 +124,20 @@ class PubSubTest(unittest.TestCase):
 
         pubsub._sow('/', '*', 0, handler, impl)
 
-        handler.write_message.assert_called_with(
+        handler.send_msg.assert_called_with(
             {'echo': 1, 'when': modified},
         )
-        handler.write_message.reset_mock()
+        handler.send_msg.reset_mock()
 
         pubsub._sow('/', '*', time.time() + 1, handler, impl)
-        self.assertFalse(handler.write_message.called)
-        handler.write_message.reset_mock()
+        self.assertFalse(handler.send_msg.called)
+        handler.send_msg.reset_mock()
 
         pubsub._sow('/', '*', time.time() - 1, handler, impl)
-        handler.write_message.assert_called_with(
+        handler.send_msg.assert_called_with(
             {'echo': 2, 'when': modified},
         )
-        handler.write_message.reset_mock()
+        handler.send_msg.reset_mock()
 
     def test_sow_fs_and_db(self):
         """Tests sow from filesystem and database."""
@@ -201,7 +201,33 @@ class PubSubTest(unittest.TestCase):
                 mock.call('/xxx', None, ''),
             ]
         )
-        handler.write_message.assert_has_calls(
+        handler.send_msg.assert_has_calls(
+            [
+                mock.call({'when': 1, 'echo': 1}),
+                mock.call({'when': 2, 'echo': 2}),
+                mock.call({'when': 3, 'echo': 3}),
+                mock.call({'when': modified, 'echo': 4}),
+            ]
+        )
+
+        # Create empty sow database, this will simulate db removing database
+        # while constructing sow.
+        #
+        with tempfile.NamedTemporaryFile(dir=sow_dir,
+                                         delete=False,
+                                         prefix='trace.db-') as temp:
+            pass
+
+        pubsub._sow('/', '*', 0, handler, impl)
+        impl.on_event.assert_has_calls(
+            [
+                mock.call('/ccc', None, None),
+                mock.call('/bbb', None, None),
+                mock.call('/aaa', None, None),
+                mock.call('/xxx', None, ''),
+            ]
+        )
+        handler.send_msg.assert_has_calls(
             [
                 mock.call({'when': 1, 'echo': 1}),
                 mock.call({'when': 2, 'echo': 2}),


### PR DESCRIPTION
 * Overrode "isEnabledFor()" at logcontext.Adapter so Adapters can passed to LogContext at py3.4.
 * moved .tmp path of spawn under manifest dir to avoid different device issues
 * Regular users can query why an application instance is in pending state in the command line.
 * Fix endpoint api as data in zookeeper is bytes
 * Store text instead of blob (bytes) in finished.db data column (which is text).
 * Fix race condition when constructing websocket sow.
 * container: Setup /var/run on tmpfs
 * mount: Switch to mount system call instead of binary.
 * Retry on invalid tickets inside container startup.
 * Properly forward tickets after forwarder restart.
 * Initialize extension module in bootstrap install
 * CLI: scheduler output supports json and yaml as well.
 * Improved websocket logging, assign each request unique id. Catch exception when trying to write to closed socket.
 * ldap: Add and leverage support for paged searches