### PR TITLE
Sync with 2018.01.05-2

### DIFF
--- a/lib/python/treadmill/ad/gmsa.py
+++ b/lib/python/treadmill/ad/gmsa.py
@@ -15,16 +15,16 @@ import os
 import ldap3
 import parse
 
-from . import _servers as servers
-
-from treadmill import dirwatch
-from treadmill import utils
-
 if os.name == 'nt':
     # Pylint warning unable to import because it is on Windows only
     import win32api  # pylint: disable=E0401
     import win32con  # pylint: disable=E0401
     import win32security  # pylint: disable=E0401
+
+from treadmill import dirwatch
+from treadmill import utils
+
+from . import _servers as servers
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -292,7 +292,7 @@ class HostGroupWatch(object):
             server_dir = os.path.join(self._placement_path,
                                       server_info['hostname'])
             self._dirwatcher.remove_dir(server_dir)
-            for proid in self._proids.keys():
+            for proid in self._proids:
                 server_dn_set = self._proids[proid]
                 if dn in server_dn_set:
                     self._remove_placement(server_info, proid)
@@ -379,7 +379,7 @@ class HostGroupWatch(object):
 
             all_proids[match] = members
 
-        for proid in all_proids.keys():
+        for proid in all_proids:
             server_dn_set = set(
                 k for (k, v) in self._get_server_dn_set(proid).items()
             )

--- a/lib/python/treadmill/appenv/linux_appenv.py
+++ b/lib/python/treadmill/appenv/linux_appenv.py
@@ -1,5 +1,5 @@
-"""Linux application environment."""
-
+"""Linux application environment.
+"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -9,8 +9,6 @@ from __future__ import unicode_literals
 import logging
 import os
 
-from . import appenv
-
 from treadmill import apphook
 from treadmill import fs
 from treadmill import iptables
@@ -18,6 +16,7 @@ from treadmill import rulefile
 from treadmill import services
 from treadmill.runtime.linux.image import fs as image_fs
 
+from . import appenv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/lib/python/treadmill/appenv/windows_appenv.py
+++ b/lib/python/treadmill/appenv/windows_appenv.py
@@ -1,16 +1,14 @@
-"""Windows application environment."""
+"""Windows application environment.
+"""
 
-
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from __future__ import absolute_import
-
 import logging
 
 from . import appenv
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,9 +21,6 @@ class WindowsAppEnvironment(appenv.AppEnvironment):
     :type root:
         `str`
     """
-
-    def __init__(self, root):
-        super(WindowsAppEnvironment, self).__init__(root)
 
     def initialize(self, _params):
         """One time initialization of the Treadmill environment."""

--- a/lib/python/treadmill/authz.py
+++ b/lib/python/treadmill/authz.py
@@ -54,9 +54,10 @@ class ClientAuthorizer(object):
         url = '/%s/%s/%s' % (user, action, resource)
         data = {}
 
-        if len(args) > 0:
+        nargs = len(args)
+        if nargs > 0:
             data['pk'] = str(args[0])
-        if len(args) > 1:
+        if nargs > 1:
             data['payload'] = args[1]
 
         # POST http://auth_server/user/action/resource

--- a/lib/python/treadmill/bootstrap/node/linux/bin/run.sh
+++ b/lib/python/treadmill/bootstrap/node/linux/bin/run.sh
@@ -77,5 +77,5 @@ exec $IONICE -c2 -n0 {{ _alias.s6_envdir }} {{ dir }}/env                  \
         exec --into cpu:/treadmill/core                                    \
              --into memory:/treadmill/core                                 \
              --into cpuset:/treadmill --                                   \
-        {{ _alias.pid1 }} -m -p                                            \
+        {{ _alias.pid1 }} -m -p --propagation slave                        \
         {{ _alias.s6_svscan }}  -s {{ dir }}/init

--- a/lib/python/treadmill/bootstrap/tkt_fwd/__init__.py
+++ b/lib/python/treadmill/bootstrap/tkt_fwd/__init__.py
@@ -1,0 +1,11 @@
+"""Treadmill ticket forwarder bootstrap.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from .. import aliases
+
+ALIASES = aliases.ALIASES

--- a/lib/python/treadmill/cgroups/__init__.py
+++ b/lib/python/treadmill/cgroups/__init__.py
@@ -49,7 +49,7 @@ def read_mounted_cgroups():
                     if op in availables:
                         subsystems2mounts.setdefault(op, []).append(fs_file)
 
-            except:  # pylint: disable=W0702
+            except Exception:  # pylint: disable=W0703
                 pass
 
     return subsystems2mounts
@@ -237,7 +237,7 @@ def available_subsystems():
                  _num_cgroups, enabled) = cgroup.split()
                 if subsys_name[0] != '#' and enabled == '1':
                     subsystems.append(subsys_name)
-            except:  # pylint: disable=W0702
+            except Exception:  # pylint: disable=W0703
                 pass
 
     return subsystems
@@ -269,7 +269,7 @@ def mounted_subsystems():
                 for op in fs_mntops.split(','):
                     if op in subsystems:
                         _SUBSYSTEMS2MOUNTS[op] = fs_file
-            except:  # pylint: disable=W0702
+            except Exception:  # pylint: disable=W0703
                 pass
 
     return _SUBSYSTEMS2MOUNTS

--- a/lib/python/treadmill/checkout/__init__.py
+++ b/lib/python/treadmill/checkout/__init__.py
@@ -78,7 +78,7 @@ def _ws_check(url):
         ws_connection = ws_client.create_connection(url, timeout=5)
         ws_connection.close()
         return True
-    except:  # pylint: disable=W0702
+    except Exception:  # pylint: disable=W0703
         return False
 
 

--- a/lib/python/treadmill/cleanup.py
+++ b/lib/python/treadmill/cleanup.py
@@ -26,19 +26,13 @@ import os
 import sys
 import time
 
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
 from treadmill import appenv
 from treadmill import dirwatch
 from treadmill import dist
 from treadmill import fs
 from treadmill import logcontext as lc
 from treadmill import runtime as app_runtime
+from treadmill import subproc
 from treadmill import supervisor
 
 
@@ -234,7 +228,7 @@ class Cleanup(object):
                 self._refresh_supervisor()
                 _LOGGER.info('svscan is running.')
                 break
-            except subprocess.CalledProcessError:
+            except subproc.CalledProcessError:
                 _LOGGER.info('Waiting on svscan running.')
                 time.sleep(0.2)
 

--- a/lib/python/treadmill/cli/__init__.py
+++ b/lib/python/treadmill/cli/__init__.py
@@ -80,16 +80,18 @@ def make_multi_command(module_name, **click_args):
             )
             return sorted([cmd.replace('_', '-') for cmd in commands])
 
-        def get_command(self, ctx, name):
+        def get_command(self, ctx, cmd_name):
             try:
-                full_name = '.'.join([module_name, name.replace('-', '_')])
+                full_name = '.'.join([module_name, cmd_name.replace('-', '_')])
                 mod = importlib.import_module(full_name)
                 return mod.init()
             except Exception:  # pylint: disable=W0703
                 with tempfile.NamedTemporaryFile(delete=False) as f:
                     traceback.print_exc(file=f)
                     click.echo(
-                        'Unable to load plugin: %s [ %s ]' % (name, f.name),
+                        'Unable to load plugin: %s [ %s ]' % (
+                            cmd_name, f.name
+                        ),
                         err=True)
                 return
 
@@ -112,11 +114,11 @@ def make_commands(section, **click_args):
             """Return list of commands in section."""
             return sorted(plugin_manager.names(section))
 
-        def get_command(self, ctx, name):
+        def get_command(self, ctx, cmd_name):
             try:
-                return plugin_manager.load(section, name).init()
+                return plugin_manager.load(section, cmd_name).init()
             except KeyError:
-                raise click.UsageError('Invalid command: %s' % name)
+                raise click.UsageError('Invalid command: %s' % cmd_name)
 
     return MCommand
 

--- a/lib/python/treadmill/cli/admin/install/tkt_fwd.py
+++ b/lib/python/treadmill/cli/admin/install/tkt_fwd.py
@@ -1,0 +1,44 @@
+"""Installs and configures Treadmill tkt-fwd locally.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import logging
+
+import click
+
+from treadmill import bootstrap
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def init():
+    """Return top level command handler.
+    """
+
+    @click.command(name='tkt-fwd')
+    @click.option('--run/--no-run', is_flag=True, default=False)
+    @click.pass_context
+    def tkt_fwd(ctx, run):
+        """Installs Treadmill tkt-fwd server.
+        """
+        dst_dir = ctx.obj['PARAMS']['dir']
+        profile = ctx.obj['PARAMS'].get('profile')
+
+        run_script = None
+        if run:
+            run_script = os.path.join(dst_dir, 'bin', 'run.sh')
+
+        bootstrap.install(
+            'tkt-fwd',
+            dst_dir,
+            ctx.obj['PARAMS'],
+            run=run_script,
+            profile=profile,
+        )
+
+    return tkt_fwd

--- a/lib/python/treadmill/cli/admin/invoke.py
+++ b/lib/python/treadmill/cli/admin/invoke.py
@@ -1,16 +1,16 @@
-"""Implementation of treadmill-admin CLI plugin."""
+"""Implementation of treadmill admin CLI API invocation.
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-
 import inspect
 import io
 
-import decorator
 import click
-
+import decorator
 import jsonschema
 
 from treadmill import authz as authz_mod
@@ -66,7 +66,7 @@ def make_command(parent, name, func):
 
         if defarg == ():
             # redefinition of the type from tuple to list.
-            argtype = cli.LIST  # pylint: disable=R0204
+            argtype = cli.LIST
             defarg = None
 
         click.option('--' + arg, default=defarg, type=argtype)(command)

--- a/lib/python/treadmill/cli/admin/master.py
+++ b/lib/python/treadmill/cli/admin/master.py
@@ -56,8 +56,12 @@ def server_group(parent):
         if parent:
             path = parent.split('/')
             bucket = None
-            for bucket, parent in zip(path, [None] + path[:-1]):
-                masterapi.create_bucket(context.GLOBAL.zk.conn, bucket, parent)
+            for bucket, bucket_parent in zip(path, [None] + path[:-1]):
+                masterapi.create_bucket(
+                    context.GLOBAL.zk.conn,
+                    bucket,
+                    bucket_parent
+                )
             assert bucket is not None, 'server topology missing.'
 
             masterapi.create_server(context.GLOBAL.zk.conn, server, bucket)

--- a/lib/python/treadmill/cli/admin/ssh.py
+++ b/lib/python/treadmill/cli/admin/ssh.py
@@ -116,8 +116,8 @@ def init():
         app_discovery.sync()
 
         # TODO: not sure how to handle mutliple instances.
-        for (app, hostport) in app_discovery.iteritems():
-            _LOGGER.info('%s :: %s', app, hostport)
+        for (endpoint, hostport) in app_discovery.iteritems():
+            _LOGGER.info('%s :: %s', endpoint, hostport)
             if hostport:
                 host, port = hostport.split(':')
                 run_ssh(host, port, ssh, list(command))

--- a/lib/python/treadmill/cli/allocation.py
+++ b/lib/python/treadmill/cli/allocation.py
@@ -1,4 +1,6 @@
-"""Manage Treadmill allocations."""
+"""Manage Treadmill allocations.
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -7,13 +9,12 @@ from __future__ import unicode_literals
 import logging
 
 import click
-
 import six
 
-from .. import cli
-from treadmill import restclient
-from treadmill import context
 from treadmill import admin
+from treadmill import cli
+from treadmill import context
+from treadmill import restclient
 
 
 _DEFAULT_PRIORITY = 1

--- a/lib/python/treadmill/cli/cell.py
+++ b/lib/python/treadmill/cli/cell.py
@@ -1,4 +1,6 @@
-"""List Treadmill cells."""
+"""List Treadmill cells.
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -8,10 +10,9 @@ import logging
 
 import click
 
-from .. import cli
-from treadmill import restclient
+from treadmill import cli
 from treadmill import context
-
+from treadmill import restclient
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/lib/python/treadmill/cli/configure.py
+++ b/lib/python/treadmill/cli/configure.py
@@ -1,4 +1,6 @@
-"""Manage Treadmill app manifest."""
+"""Manage Treadmill app manifest.
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -9,11 +11,10 @@ import logging
 
 import click
 
-from .. import cli
-from treadmill import restclient
+from treadmill import cli
 from treadmill import context
+from treadmill import restclient
 from treadmill import yamlwrapper as yaml
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/lib/python/treadmill/cli/manage/__init__.py
+++ b/lib/python/treadmill/cli/manage/__init__.py
@@ -69,12 +69,12 @@ def make_manage_multi_command(module_name, **click_args):
                 utils.sane_execvp(module_path,
                                   [os.path.basename(module_path)] + ctx.args)
 
-        def get_command(self, ctx, name):
+        def get_command(self, ctx, cmd_name):
             try:
-                return self.new_multi.get_command(ctx, name)
+                return self.new_multi.get_command(ctx, cmd_name)
             except click.UsageError:
                 pass
-            return self.old_multi.get_command(ctx, name)
+            return self.old_multi.get_command(ctx, cmd_name)
 
         def format_commands(self, ctx, formatter):
             rows = []
@@ -82,7 +82,7 @@ def make_manage_multi_command(module_name, **click_args):
                 entry_points = list(pkg_resources.iter_entry_points(
                     module_name, subcommand))
                 # Try get the help with importlib if entry_point not found
-                if len(entry_points) == 0:
+                if not entry_points:
                     cmd = self.old_multi.get_command(ctx, subcommand)
                     if cmd is None:
                         continue

--- a/lib/python/treadmill/cli/stop.py
+++ b/lib/python/treadmill/cli/stop.py
@@ -1,4 +1,6 @@
-"""Manage Treadmill app manifest."""
+"""Stop Treadmill instances.
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -6,9 +8,9 @@ from __future__ import unicode_literals
 
 import click
 
-from .. import cli
-from treadmill import restclient
+from treadmill import cli
 from treadmill import context
+from treadmill import restclient
 
 
 def init():

--- a/lib/python/treadmill/cron/__init__.py
+++ b/lib/python/treadmill/cron/__init__.py
@@ -53,21 +53,22 @@ def cron_to_dict(cron):
     _LOGGER.debug('cexpression: %r', cexpression)
 
     trigger_args = {}
-    if len(cexpression) > 0:
+    nargs = len(cexpression)
+    if nargs > 0:
         trigger_args['second'] = cexpression[0]
-    if len(cexpression) > 1:
+    if nargs > 1:
         trigger_args['minute'] = cexpression[1]
-    if len(cexpression) > 2:
+    if nargs > 2:
         trigger_args['hour'] = cexpression[2]
-    if len(cexpression) > 3:
+    if nargs > 3:
         trigger_args['day'] = cexpression[3]
-    if len(cexpression) > 4:
+    if nargs > 4:
         trigger_args['month'] = cexpression[4]
-    if len(cexpression) > 5:
+    if nargs > 5:
         trigger_args['day_of_week'] = cexpression[5]
-    if len(cexpression) > 6:
+    if nargs > 6:
         trigger_args['year'] = cexpression[6]
-    if len(cexpression) > 7:
+    if nargs > 7:
         value = cexpression[7]
         if value == '*':
             raise exc.InvalidInputError(

--- a/lib/python/treadmill/dirwatch/linux_dirwatch.py
+++ b/lib/python/treadmill/dirwatch/linux_dirwatch.py
@@ -12,9 +12,9 @@ import select
 
 import six
 
-from . import dirwatch_base
-
 from treadmill.syscall import inotify
+
+from . import dirwatch_base
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/lib/python/treadmill/diskbenchmark.py
+++ b/lib/python/treadmill/diskbenchmark.py
@@ -13,13 +13,9 @@ import shutil
 import tempfile
 
 import enum
+
 import six
 from six.moves import configparser
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 from treadmill import fs
 from treadmill import localdiskutils
@@ -261,7 +257,7 @@ def benchmark_vg(vg_name,
             shutil.rmtree(base_path)
         try:
             lvm.lvremove(benchmark_lv, group=vg_name)
-        except subprocess.CalledProcessError:
+        except subproc.CalledProcessError:
             _LOGGER.exception('lvremove error')
 
     if not check_available_volume():

--- a/lib/python/treadmill/dnsctx.py
+++ b/lib/python/treadmill/dnsctx.py
@@ -1,11 +1,10 @@
-"""DNS Context."""
+"""DNS Context.
+"""
 
-
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
-from __future__ import absolute_import
 
 import logging
 import random
@@ -99,9 +98,9 @@ def _admin_api(ctx, scope=None):
         return _lookup(ctx, scope)
 
     else:
-        for scope in ctx.get('api_scope', []):
+        for api_scope in ctx.get('api_scope', []):
             try:
-                result = _lookup(ctx, scope)
+                result = _lookup(ctx, api_scope)
                 if result:
                     return result
             except context.ContextError:

--- a/lib/python/treadmill/formatter/tablefmt.py
+++ b/lib/python/treadmill/formatter/tablefmt.py
@@ -1,4 +1,6 @@
-"""Table CLI formatter."""
+"""Table CLI formatter.
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -7,7 +9,6 @@ from __future__ import unicode_literals
 import time
 
 import prettytable
-
 import six
 
 from treadmill import yamlwrapper as yaml
@@ -79,9 +80,9 @@ def _cell(item, column, key, fmt):
         keys = key
 
     raw_value = None
-    for key in keys:
-        if key in item and item[key] is not None:
-            raw_value = item[key]
+    for k in keys:
+        if k in item and item[k] is not None:
+            raw_value = item[k]
             break
 
     if callable(fmt):

--- a/lib/python/treadmill/fs/__init__.py
+++ b/lib/python/treadmill/fs/__init__.py
@@ -19,11 +19,6 @@ import shutil
 
 import six
 
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
 if os.name == 'nt':
     # E0401: Unable to import windows only pakages
     import win32api  # pylint: disable=E0401
@@ -267,7 +262,7 @@ def _tar_impl(sources, **args):
             else:
                 archive.add(sources.rstrip('/'), '/')
 
-    except:  # pylint: disable=W0702
+    except Exception:  # pylint: disable=W0703
         _LOGGER.exception('Error taring up files')
         raise
 

--- a/lib/python/treadmill/fs/linux.py
+++ b/lib/python/treadmill/fs/linux.py
@@ -12,14 +12,6 @@ import logging
 import os
 import re
 
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
-
 from treadmill import exc
 from treadmill import fs
 from treadmill import subproc
@@ -222,7 +214,7 @@ def blk_fs_info(block_dev):
     #       in the result.
     try:
         output = subproc.check_output(['dumpe2fs', '-h', block_dev])
-    except subprocess.CalledProcessError:
+    except subproc.CalledProcessError:
         return res
 
     for line in output.split(os.linesep):

--- a/lib/python/treadmill/gssapiprotocol.py
+++ b/lib/python/treadmill/gssapiprotocol.py
@@ -279,7 +279,7 @@ class GSSAPILineServer(basic.LineReceiver):  # pylint: disable=C0103
 
     @abc.abstractmethod
     def got_line(self, data):
-        """Invoked after authentication is done, with decrypted line as arg.
+        """Invoked after authentication is done, with decrypted data as arg.
 
         :param ``bytes`` data:
             Data received from the client.

--- a/lib/python/treadmill/journal/plugin.py
+++ b/lib/python/treadmill/journal/plugin.py
@@ -33,9 +33,10 @@ class BaseJournaler(object):
         pk = None
         payload = {}
 
-        if len(args) > 0:
+        nargs = len(args)
+        if nargs > 0:
             pk = str(args[0])
-        if len(args) > 1:
+        if nargs > 1:
             payload = args[1]
 
         user = self._user_clbk()
@@ -53,7 +54,8 @@ class BaseJournaler(object):
         """ log end step of the journal after API is called"""
         pk = None
 
-        if len(args) > 0:
+        nargs = len(args)
+        if nargs > 0:
             pk = str(args[0])
 
         user = self._user_clbk()
@@ -71,7 +73,8 @@ class BaseJournaler(object):
         """ log abort step of the journal in case API is aborted"""
         pk = None
 
-        if len(args) > 0:
+        nargs = len(args)
+        if nargs > 0:
             pk = str(args[0])
 
         payload = {'error': str(exception)}

--- a/lib/python/treadmill/kafka/__init__.py
+++ b/lib/python/treadmill/kafka/__init__.py
@@ -1,4 +1,5 @@
-"""Treadmill Kafka API"""
+"""Treadmill Kafka API
+"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -219,9 +220,6 @@ def get_brokers(cellname, domain, zkclient, app_pattern=None,
         return brokers
 
     if app_pattern:
-        # TODO: pylint complains about:
-        #                Redefinition of brokers type from list to set
-        # pylint: disable=R0204
         brokers = _get_kafka_endpoint(zkclient, app_pattern, endpoint,
                                       watcher_cb=watcher_cb)
 

--- a/lib/python/treadmill/keytabs.py
+++ b/lib/python/treadmill/keytabs.py
@@ -144,10 +144,13 @@ def run_server(locker):
             )
 
         @utils.exit_on_unhandled
-        def got_line(self, line):
-            """Callback on received line.
+        def got_line(self, data):
+            """Invoked after authentication is done, with decrypted data as arg.
+
+            :param ``bytes`` data:
+                Data received from the client.
             """
-            items = line.split()
+            items = data.split()
             action = items[0]
 
             if action == b'get':

--- a/lib/python/treadmill/localdiskutils.py
+++ b/lib/python/treadmill/localdiskutils.py
@@ -13,11 +13,6 @@ import re
 
 import six
 
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
 from treadmill import exc
 from treadmill import fs
 from treadmill import lvm
@@ -77,7 +72,7 @@ def init_vg(group, block_dev):
         lvm.vgactivate(group)
         return
 
-    except subprocess.CalledProcessError:
+    except subproc.CalledProcessError:
         # The Volume group doesn't exist, more work to do
         pass
 
@@ -108,7 +103,7 @@ def loop_dev_for(filename):
     :returns:
         Name of the loop device or None if not found
     :raises:
-        subprocess.CalledProcessError if the file doesn't exist
+        subproc.CalledProcessError if the file doesn't exist
     """
     filename = os.path.realpath(filename)
     loop_dev = subproc.check_output(
@@ -201,7 +196,9 @@ def init_block_dev(img_name, img_location, img_size='-2G'):
 
     try:
         loop_dev = loop_dev_for(filename)
-    except subprocess.CalledProcessError:
+
+    except subproc.CalledProcessError:
+        # The file doesn't exist.
         loop_dev = None
 
     # Assign a loop device (if not already assigned)
@@ -275,7 +272,7 @@ def activate_vg(vg_name):
     try:
         lvm.vgactivate(group=vg_name)
         return True
-    except subprocess.CalledProcessError:
+    except subproc.CalledProcessError:
         return False
 
 

--- a/lib/python/treadmill/metrics/__init__.py
+++ b/lib/python/treadmill/metrics/__init__.py
@@ -64,7 +64,7 @@ _MEMORY_TYPE = [
 def cgrp_meminfo(cgrp, *pseudofiles):
     """Grab the cgrp mem limits"""
 
-    if pseudofiles is None or len(pseudofiles) == 0:
+    if pseudofiles is None or not pseudofiles:
         pseudofiles = _MEMORY_TYPE
 
     metrics = {}
@@ -103,7 +103,7 @@ _BLKIO_INFO_TYPE = [
 def read_blkio_info_stats(cgrp, *pseudofiles):
     """Read bklio statistics for the given Treadmill app.
     """
-    if pseudofiles is None or len(pseudofiles) == 0:
+    if pseudofiles is None or not pseudofiles:
         pseudofiles = _BLKIO_INFO_TYPE
 
     metrics = {}
@@ -124,7 +124,7 @@ _BLKIO_VALUE_TYPE = [
 def read_blkio_value_stats(cgrp, *pseudofiles):
     """ read blkio value based cgroup pseudofiles
     """
-    if pseudofiles is None or len(pseudofiles) == 0:
+    if pseudofiles is None or not pseudofiles:
         pseudofiles = _BLKIO_VALUE_TYPE
 
     metrics = {}

--- a/lib/python/treadmill/metrics/engine.py
+++ b/lib/python/treadmill/metrics/engine.py
@@ -73,10 +73,18 @@ class CgroupReader(object):
     def list(self):
         """Get all cgroups item name in a  list"""
         return (
-            ['treadmill.{}'.format(cgrp)
-             for cgrp in self.cache['treadmill'].keys()] +
-            ['core.{}'.format(cgrp) for cgrp in self.cache['core'].keys()] +
-            ['app.{}'.format(cgrp) for cgrp in self.cache['app'].keys()]
+            [
+                'treadmill.{}'.format(cgrp)
+                for cgrp in self.cache['treadmill']
+            ] +
+            [
+                'core.{}'.format(cgrp)
+                for cgrp in self.cache['core']
+            ] +
+            [
+                'app.{}'.format(cgrp)
+                for cgrp in self.cache['app']
+            ]
         )
 
     def _loop(self):

--- a/lib/python/treadmill/monitor.py
+++ b/lib/python/treadmill/monitor.py
@@ -17,14 +17,10 @@ import os
 import enum
 import six
 
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
 from treadmill import appevents
 from treadmill import dirwatch
 from treadmill import fs
+from treadmill import subproc
 from treadmill import supervisor
 from treadmill import utils
 
@@ -193,7 +189,7 @@ class Monitor(object):
             # Service is up, nothing to do.
             return
 
-        except subprocess.CalledProcessError as err:
+        except subproc.CalledProcessError as err:
             if err.returncode == supervisor.ERR_NO_SUP:
                 # Watching a directory without supervisor, nothing to do.
                 return
@@ -354,7 +350,7 @@ class MonitorContainerCleanup(MonitorDownAction):
                 supervisor.SvscanControlAction.alarm,
                 supervisor.SvscanControlAction.nuke
             ])
-        except subprocess.CalledProcessError as err:
+        except subproc.CalledProcessError as err:
             _LOGGER.warning('Failed to nuke svscan: %r', self._running_dir)
 
         return True
@@ -658,7 +654,7 @@ class CleanupMonitorRestartPolicy(MonitorRestartPolicy):
     """
 
     __slots__ = (
-        '_tm_env'
+        '_tm_env',
     )
 
     def __init__(self, tm_env):

--- a/lib/python/treadmill/postmortem.py
+++ b/lib/python/treadmill/postmortem.py
@@ -102,7 +102,7 @@ def collect(approot, archive_filename):
         _LOGGER.info('node info archive file: %s', archive_filename)
         shutil.rmtree(destroot)
         return archive_filename
-    except:  # pylint: disable=W0702
+    except Exception:  # pylint: disable=W0703
         # if tar bar is not generated successfully, we keep destroot
         # we can find destroot path in log to check the files
         _LOGGER.exception('Failed to generate node info archive')

--- a/lib/python/treadmill/reports.py
+++ b/lib/python/treadmill/reports.py
@@ -1,4 +1,5 @@
-"""Handles reports over scheduler data."""
+"""Handles reports over scheduler data.
+"""
 
 from __future__ import division
 from __future__ import unicode_literals

--- a/lib/python/treadmill/rest/__init__.py
+++ b/lib/python/treadmill/rest/__init__.py
@@ -106,7 +106,7 @@ class TcpRestServer(RestServer):
             except KeyError:
                 _LOGGER.error('Unsupported auth type: %s', self.auth_type)
                 raise
-            except:
+            except Exception:
                 _LOGGER.exception('Unable to load auth plugin.')
                 raise
         else:
@@ -141,7 +141,7 @@ class UdsRestServer(RestServer):
             except KeyError:
                 _LOGGER.error('Unsupported auth type: %s', self.auth_type)
                 raise
-            except:
+            except Exception:
                 _LOGGER.exception('Unable to load auth plugin.')
                 raise
 

--- a/lib/python/treadmill/restclient.py
+++ b/lib/python/treadmill/restclient.py
@@ -88,8 +88,6 @@ class NotFoundError(Exception):
     Attributes:
     message -- message to return
     """
-    def __init__(self, msg):
-        super(NotFoundError, self).__init__(msg)
 
 
 class AlreadyExistsError(Exception):
@@ -98,8 +96,6 @@ class AlreadyExistsError(Exception):
     Attributes:
     message -- message to return
     """
-    def __init__(self, msg):
-        super(AlreadyExistsError, self).__init__(msg)
 
 
 class MaxRequestRetriesError(Exception):

--- a/lib/python/treadmill/runtime/linux/_finish.py
+++ b/lib/python/treadmill/runtime/linux/_finish.py
@@ -332,7 +332,7 @@ def _cleanup_exception_rules(tm_env, container_dir, app):
             'treadmill.firewall.plugins', 'firewall'
         )
         firewall_plugin.cleanup_exception_rules(tm_env, container_dir, app)
-    except:  # pylint: disable=W0702
+    except Exception:  # pylint: disable=W0703
         _LOGGER.exception(
             'Error in firewall plugin, skip cleaning firewall exception rules.'
         )

--- a/lib/python/treadmill/runtime/linux/_run.py
+++ b/lib/python/treadmill/runtime/linux/_run.py
@@ -123,6 +123,7 @@ def run(tm_env, container_dir, manifest):
             '-s',
             os.path.join(container_dir, 'sys')
         ],
+        propagation='slave',
         # We need to keep our mapped ports open
         close_fds=False
     )
@@ -250,7 +251,7 @@ def _unshare_network(tm_env, container_dir, app):
             'treadmill.firewall.plugins', 'firewall'
         )
         firewall_plugin.apply_exception_rules(tm_env, container_dir, app)
-    except:  # pylint: disable=W0702
+    except Exception:  # pylint: disable=W0703
         _LOGGER.exception(
             'Error in firewall plugin, skip applying firewall exception rules.'
         )

--- a/lib/python/treadmill/runtime/linux/image/native.py
+++ b/lib/python/treadmill/runtime/linux/image/native.py
@@ -441,8 +441,9 @@ def share_cgroup_info(root_dir, cgrp):
 
 class NativeImage(_image_base.Image):
     """Represents a native image."""
+
     __slots__ = (
-        'tm_env'
+        'tm_env',
     )
 
     def __init__(self, tm_env):
@@ -471,9 +472,6 @@ class NativeImage(_image_base.Image):
 
 class NativeImageRepository(_repository_base.ImageRepository):
     """A collection of native images."""
-
-    def __init__(self, tm_env):
-        super(NativeImageRepository, self).__init__(tm_env)
 
     def get(self, url):
         return NativeImage(self.tm_env)

--- a/lib/python/treadmill/runtime/linux/image/tar.py
+++ b/lib/python/treadmill/runtime/linux/image/tar.py
@@ -19,12 +19,11 @@ import requests_kerberos
 
 from six.moves import urllib_parse
 
+from treadmill import fs
+
 from . import _image_base
 from . import _repository_base
 from . import native
-
-from treadmill import fs
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,9 +64,10 @@ def _sha256sum(path):
 
 class TarImage(_image_base.Image):
     """Represents a TAR image."""
+
     __slots__ = (
-        'tm_env'
-        'image_path'
+        'tm_env',
+        'image_path',
     )
 
     def __init__(self, tm_env, image_path):
@@ -88,9 +88,6 @@ class TarImage(_image_base.Image):
 
 class TarImageRepository(_repository_base.ImageRepository):
     """A collection of TAR images."""
-
-    def __init__(self, tm_env):
-        super(TarImageRepository, self).__init__(tm_env)
 
     def get(self, url):
         images_dir = os.path.join(self.tm_env.images_dir, TAR_DIR)

--- a/lib/python/treadmill/runtime/linux/runtime.py
+++ b/lib/python/treadmill/runtime/linux/runtime.py
@@ -9,14 +9,8 @@ from __future__ import unicode_literals
 import logging
 import os
 
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
 from treadmill import appcfg
+from treadmill import subproc
 from treadmill import supervisor
 from treadmill.runtime import runtime_base
 
@@ -28,11 +22,6 @@ _LOGGER = logging.getLogger(__name__)
 
 class LinuxRuntime(runtime_base.RuntimeBase):
     """Linux Treadmill runtime."""
-
-    def __init__(self, tm_env, container_dir, param=None):
-        super(LinuxRuntime, self).__init__(
-            tm_env, container_dir, param
-        )
 
     def _can_run(self, manifest):
         try:
@@ -56,7 +45,7 @@ class LinuxRuntime(runtime_base.RuntimeBase):
         try:
             supervisor.control_service(services_dir,
                                        supervisor.ServiceControlAction.kill)
-        except subprocess.CalledProcessError as err:
+        except subproc.CalledProcessError as err:
             if err.returncode in (supervisor.ERR_COMMAND,
                                   supervisor.ERR_NO_SUP):
                 # Ignore the error if there is no supervisor

--- a/lib/python/treadmill/schema.py
+++ b/lib/python/treadmill/schema.py
@@ -78,7 +78,7 @@ def schema(*schemas, **kwschemas):
             if kw_value != kw_default:
                 kwargs[kw_name] = kw_value
 
-        if len(defaults):
+        if defaults:
             args = list(args)[:-len(defaults)]
         else:
             args = list(args)

--- a/lib/python/treadmill/services/_base_service.py
+++ b/lib/python/treadmill/services/_base_service.py
@@ -81,9 +81,6 @@ class ResourceServiceError(exc.TreadmillError):
     """
     __slots__ = ()
 
-    def __init__(self, message):
-        super(ResourceServiceError, self).__init__(message)
-
 
 class ResourceServiceRequestError(ResourceServiceError):
     """Resource Service Request error.
@@ -101,9 +98,6 @@ class ResourceServiceTimeoutError(ResourceServiceError, socket.timeout):
     """Resource Service timeout.
     """
     __slots__ = ()
-
-    def __init__(self, message):
-        super(ResourceServiceTimeoutError, self).__init__(message)
 
 
 class ResourceServiceClient(object):

--- a/lib/python/treadmill/services/cgroup_service.py
+++ b/lib/python/treadmill/services/cgroup_service.py
@@ -47,6 +47,7 @@ class CgroupResourceService(BaseResourceServiceImpl):
         # NOTE(boysson): We assume cgroup initialization is done by cginit
         #                during node startup. Otherwise it would need to be
         #                done here.
+        _LOGGER.info('Cgroup service initialized')
 
     def synchronize(self):
         # NOTE(boysson): We assume cgroup initialization is done by cginit

--- a/lib/python/treadmill/services/localdisk_service.py
+++ b/lib/python/treadmill/services/localdisk_service.py
@@ -13,16 +13,12 @@ import os
 
 import six
 
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
 from treadmill import cgroups
 from treadmill import cgutils
 from treadmill import localdiskutils
 from treadmill import logcontext as lc
 from treadmill import lvm
+from treadmill import subproc
 from treadmill import utils
 
 from ._base_service import BaseResourceServiceImpl
@@ -289,7 +285,7 @@ class LocalDiskResourceService(BaseResourceServiceImpl):
         self._volumes.pop(uniqueid, None)
         try:
             lvm.lvdisplay(uniqueid, group=self._vg_name)
-        except subprocess.CalledProcessError:
+        except subproc.CalledProcessError:
             _LOGGER.warning('Ignoring unknow volume %r', uniqueid)
             return False
 

--- a/lib/python/treadmill/services/network_service.py
+++ b/lib/python/treadmill/services/network_service.py
@@ -13,15 +13,11 @@ import os
 import netifaces
 import six
 
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
+from treadmill import iptables
 from treadmill import logcontext as lc
 from treadmill import netdev
+from treadmill import subproc
 from treadmill import vipfile
-from treadmill import iptables
 
 from ._base_service import BaseResourceServiceImpl
 
@@ -101,7 +97,7 @@ class NetworkResourceService(BaseResourceServiceImpl):
             netdev.link_set_up(self._TM_DEV1)
             netdev.link_set_up(self._TMBR_DEV)
 
-        except subprocess.CalledProcessError:
+        except subproc.CalledProcessError:
             need_init = True
 
         if need_init:
@@ -292,19 +288,19 @@ class NetworkResourceService(BaseResourceServiceImpl):
             #                 bridge.
             netdev.link_set_down(self._TM_DEV0)
             netdev.bridge_delete(self._TM_DEV0)
-        except subprocess.CalledProcessError:
+        except subproc.CalledProcessError:
             pass
 
         try:
             netdev.link_set_down(self._TM_DEV0)
             netdev.link_del_veth(self._TM_DEV0)
-        except subprocess.CalledProcessError:
+        except subproc.CalledProcessError:
             pass
 
         try:
             netdev.link_set_down(self._TMBR_DEV)
             netdev.bridge_delete(self._TMBR_DEV)
-        except subprocess.CalledProcessError:
+        except subproc.CalledProcessError:
             pass
 
         netdev.bridge_create(self._TMBR_DEV)

--- a/lib/python/treadmill/spawn/cleanup.py
+++ b/lib/python/treadmill/spawn/cleanup.py
@@ -10,16 +10,10 @@ import logging
 import os
 import shutil
 
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
-from treadmill import spawn
-from treadmill import fs
 from treadmill import dirwatch
+from treadmill import fs
+from treadmill import spawn
+from treadmill import subproc
 from treadmill import supervisor
 from treadmill.spawn import utils as spawn_utils
 
@@ -30,7 +24,7 @@ class Cleanup(object):
     """Treadmill spawn cleanup."""
 
     __slots__ = (
-        'paths'
+        'paths',
     )
 
     def __init__(self, root, buckets=spawn.BUCKETS):
@@ -45,7 +39,7 @@ class Cleanup(object):
                 supervisor.SvscanControlAction.alarm,
                 supervisor.SvscanControlAction.nuke
             ))
-        except subprocess.CalledProcessError as ex:
+        except subproc.CalledProcessError as ex:
             _LOGGER.warning(ex)
 
     def _on_created(self, path):

--- a/lib/python/treadmill/spawn/manifest_watch.py
+++ b/lib/python/treadmill/spawn/manifest_watch.py
@@ -12,11 +12,6 @@ import os
 
 import six
 
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
-
 from treadmill import spawn
 from treadmill import fs
 from treadmill import dirwatch
@@ -33,7 +28,7 @@ class ManifestWatch(object):
     """Treadmill spawn manifest watch."""
 
     __slots__ = (
-        'paths'
+        'paths',
     )
 
     def __init__(self, root, buckets=spawn.BUCKETS):
@@ -65,7 +60,7 @@ class ManifestWatch(object):
         try:
             supervisor.control_svscan(scan_dir,
                                       supervisor.SvscanControlAction.alarm)
-        except subprocess.CalledProcessError as ex:
+        except subproc.CalledProcessError as ex:
             _LOGGER.warning(ex)
 
     def _create_instance(self, path):

--- a/lib/python/treadmill/sproc/cgroup.py
+++ b/lib/python/treadmill/sproc/cgroup.py
@@ -169,7 +169,7 @@ def init():
         for subsystem in subsystems:
             try:
                 _transfer_processes(subsystem, group_from, group_to)
-            except:  # pylint: disable=W0702
+            except Exception:  # pylint: disable=W0703
                 pass
 
     @top.command(name='cleanup')

--- a/lib/python/treadmill/sproc/presence.py
+++ b/lib/python/treadmill/sproc/presence.py
@@ -14,22 +14,17 @@ import time
 import traceback
 
 import click
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 from treadmill import appenv
 from treadmill import appevents
-from treadmill import exc
 from treadmill import context
+from treadmill import exc
 from treadmill import presence
+from treadmill import subproc
 from treadmill import supervisor
 from treadmill import tickets
-from treadmill import zkutils
 from treadmill import utils
+from treadmill import zkutils
 
 from treadmill.appcfg import abort as app_abort
 from treadmill.appcfg import manifest as app_manifest
@@ -61,7 +56,7 @@ def _start_service_sup(tm_env, manifest, container_dir):
             os.path.join(container_dir, 'sys', 'start_container'),
             supervisor.ServiceControlAction.once
         )
-    except subprocess.CalledProcessError:
+    except subproc.CalledProcessError:
         raise exc.ContainerSetupError('start_container')
 
 

--- a/lib/python/treadmill/sproc/tickets.py
+++ b/lib/python/treadmill/sproc/tickets.py
@@ -20,12 +20,6 @@ import socket
 import time
 
 import click
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 from treadmill import tickets
 from treadmill import context
@@ -60,7 +54,7 @@ def _renew_tickets(tkt_spool_dir):
                 environ={'KRB5CCNAME': 'FILE:' + tkt},
             )
             _LOGGER.info('Tickets renewed successfully.')
-        except subprocess.CalledProcessError as err:
+        except subproc.CalledProcessError as err:
             _LOGGER.info('Tickets not renewable, kinit rc: %s',
                          err.returncode)
         except OSError as os_err:

--- a/lib/python/treadmill/sproc/version_monitor.py
+++ b/lib/python/treadmill/sproc/version_monitor.py
@@ -20,12 +20,6 @@ import io
 import time
 
 import click
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 from treadmill import appenv
 from treadmill import context
@@ -126,7 +120,7 @@ def init():
                     try:
                         subproc.check_call(cli_cmd)
                         # Record successful upgrade.
-                    except subprocess.CalledProcessError:
+                    except subproc.CalledProcessError:
                         _LOGGER.exception('Upgrade failed.')
                         # Immediately trigger a watchdog timeout
                         watchdogs.create(

--- a/lib/python/treadmill/subproc.py
+++ b/lib/python/treadmill/subproc.py
@@ -16,6 +16,9 @@ if six.PY2 and os.name == 'posix':
 else:
     import subprocess  # pylint: disable=wrong-import-order
 
+# pylint: disable=wrong-import-position
+from subprocess import CalledProcessError  # pylint: disable=wrong-import-order
+
 from treadmill import dist
 from treadmill import plugin_manager
 from treadmill import utils
@@ -139,7 +142,7 @@ def check_call(cmdline, environ=(), runas=None, **kwargs):
                                    **kwargs)
         _LOGGER.debug('Finished, rc: %d', rc)
         return rc
-    except subprocess.CalledProcessError as exc:
+    except CalledProcessError as exc:
         _LOGGER.warning('Error, rc: %d, %s', exc.returncode, exc.output)
         raise
 
@@ -170,7 +173,7 @@ def check_output(cmdline, environ=(), **kwargs):
                                       **kwargs)
 
         _LOGGER.debug('Finished.')
-    except subprocess.CalledProcessError as exc:
+    except CalledProcessError as exc:
         _LOGGER.warning(exc.output)
         raise
 
@@ -226,7 +229,7 @@ def invoke(cmd, cmd_input=None, use_except=False, **environ):
     :returns:
         (``(int, str)``) -- Return code and output from executed process
     :raises:
-        :class:`subprocess.CalledProcessError`
+        :class:`CalledProcessError`
     """
     _LOGGER.debug('invoke: %r', cmd)
     args = _alias_command(cmd)
@@ -257,15 +260,16 @@ def invoke(cmd, cmd_input=None, use_except=False, **environ):
     out = out.decode()
 
     if retcode != 0 and use_except:
-        raise subprocess.CalledProcessError(cmd=args,
-                                            returncode=retcode,
-                                            output=out)
+        raise CalledProcessError(cmd=args,
+                                 returncode=retcode,
+                                 output=out)
 
     return (retcode, out)
 
 
 def exec_pid1(cmd, ipc=True, mount=True, proc=True,
-              close_fds=True, restore_signals=True):
+              close_fds=True, restore_signals=True,
+              propagation=None):
     """Exec command line under pid1.
     """
     pid1 = resolve('pid1')
@@ -277,6 +281,10 @@ def exec_pid1(cmd, ipc=True, mount=True, proc=True,
         args.append('-m')
     if proc:
         args.append('-p')
+    if propagation is not None:
+        args.append('--propagation')
+        args.append(propagation)
+
     args.extend(safe_cmd)
     _LOGGER.debug('exec_pid1: %r', args)
     utils.sane_execvp(args[0], args,
@@ -290,3 +298,16 @@ def safe_exec(cmd):
     _LOGGER.debug('safe_exec: %r', safe_cmd)
 
     utils.sane_execvp(safe_cmd[0], safe_cmd)
+
+
+__all__ = [
+    'call',
+    'CalledProcessError',
+    'check_call',
+    'check_output',
+    'exec_pid1',
+    'get_aliases',
+    'invoke',
+    'resolve',
+    'safe_exec',
+]

--- a/lib/python/treadmill/supervisor/__init__.py
+++ b/lib/python/treadmill/supervisor/__init__.py
@@ -55,12 +55,6 @@ import time
 import enum
 
 import jinja2
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 from treadmill import fs
 from treadmill import utils
@@ -488,7 +482,7 @@ def is_supervised(service_dir):
     try:
         subproc.check_call([_get_cmd('svok'), service_dir])
         return True
-    except subprocess.CalledProcessError as err:
+    except subproc.CalledProcessError as err:
         # svok returns 1 when the service directory is not supervised.
         if err.returncode == 1:
             return False
@@ -502,7 +496,7 @@ def control_service(service_dir, actions, wait=None, timeout=0):
     :returns:
         ``True`` - Command was successuful.
         ``False`` - Command timedout (only if `wait` was provided).
-    :raises ``subprocess.CalledProcessError``:
+    :raises ``subproc.CalledProcessError``:
         With `returncode` set to `ERR_NO_SUP` if the service is not supervised.
         With `returncode` set to `ERR_COMMAND` if there is a problem
         communicating with the supervisor.
@@ -530,7 +524,7 @@ def control_service(service_dir, actions, wait=None, timeout=0):
         if wait is not None:
             wait_service(service_dir, wait, timeout=timeout)
 
-    except subprocess.CalledProcessError as err:
+    except subproc.CalledProcessError as err:
         if err.returncode == ERR_TIMEOUT:
             return False
         else:
@@ -582,7 +576,7 @@ def ensure_not_supervised(service_dir):
             control_service(service, ServiceControlAction.exit,
                             ServiceWaitAction.really_down,
                             timeout=1000)
-        except subprocess.CalledProcessError:
+        except subproc.CalledProcessError:
             # Ignore this as supervisor may be down
             pass
 

--- a/lib/python/treadmill/supervisor/s6/services.py
+++ b/lib/python/treadmill/supervisor/s6/services.py
@@ -59,7 +59,7 @@ class BundleService(_service_base.Service):
         if not self._contents and not os.path.exists(self._contents_file):
             raise ValueError('Invalid Bundle: No content')
         elif self._contents is not None:
-            if not len(self._contents):
+            if not self._contents:
                 raise ValueError('Invalid Bundle: empty')
             _utils.set_list_write(self._contents_file, self._contents)
 

--- a/lib/python/treadmill/syscall/eventfd.py
+++ b/lib/python/treadmill/syscall/eventfd.py
@@ -88,6 +88,7 @@ class EFDFlags(enum.IntEnum):
 
         return masks
 
+
 #: Provice semaphore-like semantics for reads from the new file descriptor.
 #: (since Linux 2.6.30)
 EFD_SEMAPHORE = EFDFlags.SEMAPHORE

--- a/lib/python/treadmill/syscall/inotify.py
+++ b/lib/python/treadmill/syscall/inotify.py
@@ -130,6 +130,7 @@ class INAddWatchFlags(enum.IntEnum):
     #: Only watch the path if it's a directory.
     ONLYDIR = 0x01000000
 
+
 #: Don't dereference pathname if it is a symbolic link.
 #: (since Linux 2.6.15)
 IN_DONT_FOLLOW = INAddWatchFlags.DONT_FOLLOW
@@ -200,8 +201,7 @@ def _parse_buffer(event_buffer):
         event_buffer = event_buffer[INOTIFY_EVENT_HDRSIZE + length:]
         yield wd, mask, cookie, name
 
-    assert len(event_buffer) == 0, ('Unparsed bytes left in buffer: %r' %
-                                    event_buffer)
+    assert not event_buffer, 'Unparsed bytes left in buffer: %r' % event_buffer
 
 
 ###############################################################################
@@ -235,6 +235,7 @@ class INEvent(enum.IntEnum):
     ISDIR = 0x40000000
     Q_OVERFLOW = 0x00004000
     UNMOUNT = 0x00002000
+
 
 #: File was accessed (read).
 IN_ACCESS = INEvent.ACCESS

--- a/lib/python/treadmill/syscall/sigprocmask.py
+++ b/lib/python/treadmill/syscall/sigprocmask.py
@@ -63,9 +63,7 @@ def sigprocmask(how, sigset, save_mask=True):
     if save_mask:
         old_set = SigSet()
     else:
-        # pylint - Redefinition of old_set type from
-        #          treadmill.syscall._sigsetops.SigSet to int
-        old_set = 0  # pylint: disable=R0204
+        old_set = 0
 
     new_set_p = ctypes.pointer(new_set)
     old_set_p = ctypes.pointer(old_set)
@@ -96,6 +94,7 @@ class SigProcMaskHow(enum.IntEnum):
     SIG_BLOCK = 0
     SIG_UNBLOCK = 1
     SIG_SETMASK = 2
+
 
 #: Block signals.
 SIG_BLOCK = SigProcMaskHow.SIG_BLOCK

--- a/lib/python/treadmill/sysinfo.py
+++ b/lib/python/treadmill/sysinfo.py
@@ -1,4 +1,5 @@
-"""Helper module to get system related information."""
+"""Helper module to get system related information.
+"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -105,7 +106,7 @@ def _proc_info_windows(pid):
     """Returns process exe filename and start time."""
     try:
         process = psutil.Process(pid)
-    except:
+    except Exception:
         raise exc.InvalidInputError('proc', 'pid is undefined.')
 
     return namedtuple('proc', 'filename ppid starttime')(process.name(),

--- a/lib/python/treadmill/utils.py
+++ b/lib/python/treadmill/utils.py
@@ -543,6 +543,7 @@ def _setup_sigs():
         for sigval, signames in sigs.items()
     }
 
+
 _SIG2NAME = _setup_sigs()
 del _setup_sigs
 
@@ -583,7 +584,7 @@ def make_signal_flag(*signals):
     _LOGGER.info('Configuring signal flag: %r', signals)
     signalled = set()
 
-    def _handler(signum, frame_unused):
+    def _handler(signum, _frame):
         """Signal handler."""
         signalled.add(signum)
 
@@ -694,6 +695,7 @@ def get_current_username():
         return win32api.GetUserName()
     else:
         return pwd.getpwuid(os.getuid()).pw_name
+
 
 # List of signals that can be manipulated
 if sys.platform == 'win32':

--- a/lib/python/treadmill/websocket/__init__.py
+++ b/lib/python/treadmill/websocket/__init__.py
@@ -61,7 +61,7 @@ def make_handler(pubsub):
                 return False
             return sub_id is None or sub_id in self._subscriptions
 
-        def open(self):
+        def open(self, *args, **kwargs):
             """Called when connection is opened.
 
             Override if you want to do something else besides log the action.
@@ -120,24 +120,24 @@ def make_handler(pubsub):
             _LOGGER.debug('parsed_origin: %r', parsed_origin)
             return True
 
-        def on_message(self, jmessage):
+        def on_message(self, message):
             """Manage event subscriptions."""
             if not pubsub:
                 _LOGGER.fatal('pubsub is not configured, ignore.')
                 self.send_error_msg('Fatal: unexpected error', close_conn=True)
 
             _LOGGER.info('[%s] Received message: %s',
-                         self._request_id, jmessage)
+                         self._request_id, message)
 
             sub_id = None
             close_conn = True
             try:
-                message = json.loads(jmessage)
+                sub_msg = json.loads(message)
 
-                sub_id = message.get('sub-id')
+                sub_id = sub_msg.get('sub-id')
                 close_conn = sub_id is None
 
-                if message.get('unsubscribe') is True:
+                if sub_msg.get('unsubscribe') is True:
                     _LOGGER.info('[%s] Unsubscribing %s',
                                  self._request_id, sub_id)
                     try:
@@ -156,7 +156,7 @@ def make_handler(pubsub):
                     )
                     return
 
-                topic = message.get('topic')
+                topic = sub_msg.get('topic')
                 impl = pubsub.impl.get(topic)
                 if not impl:
                     self.send_error_msg(
@@ -165,9 +165,9 @@ def make_handler(pubsub):
                     )
                     return
 
-                subscription = impl.subscribe(message)
-                since = message.get('since', 0)
-                snapshot = message.get('snapshot', False)
+                subscription = impl.subscribe(sub_msg)
+                since = sub_msg.get('since', 0)
+                snapshot = sub_msg.get('snapshot', False)
 
                 if sub_id and not snapshot:
                     _LOGGER.info('[%s] Adding subscription %s',
@@ -184,7 +184,7 @@ def make_handler(pubsub):
                 self.send_error_msg(str(err),
                                     sub_id=sub_id, close_conn=close_conn)
 
-        def data_received(self, message):
+        def data_received(self, chunk):
             """Passthrough of abstract method data_received"""
             pass
 

--- a/lib/python/treadmill/yamlwrapper.py
+++ b/lib/python/treadmill/yamlwrapper.py
@@ -32,6 +32,7 @@ def _repr_unicode(dumper, data):
     else:
         return dumper.represent_scalar(u'tag:yaml.org,2002:str', data)
 
+
 if six.PY2:
     # pylint: disable=unicode-builtin,undefined-variable
     yaml.add_representer(str, _repr_bytes)
@@ -45,13 +46,15 @@ def _repr_tuple(dumper, data):
     """
     return dumper.represent_list(list(data))
 
+
 yaml.add_representer(tuple, _repr_tuple)
 
 
-def _repr_none(dumper, data_unused):
+def _repr_none(dumper, _data):
     """Fix yaml None representation (use ~).
     """
     return dumper.represent_scalar(u'tag:yaml.org,2002:null', '~')
+
 
 yaml.add_representer(type(None), _repr_none)
 

--- a/lib/python/treadmill/zkutils.py
+++ b/lib/python/treadmill/zkutils.py
@@ -132,7 +132,7 @@ def make_safe_create(zkclient):
     """Makes a wrapper for kazoo.client.create enforcing default acl."""
     _create = zkclient.create
 
-    def safe_create(self_unused, path, value='', acl=None, ephemeral=False,
+    def safe_create(_self, path, value='', acl=None, ephemeral=False,
                     sequence=False, makepath=False):
         """Safe wrapper around kazoo.client.create"""
         return _create(path, value=value, acl=make_default_acl(acl),
@@ -146,7 +146,7 @@ def make_safe_ensure_path(zkclient):
     """Makes a wrapper for kazoo.client.ensure_path enforcing default acl."""
     ensure_path = zkclient.ensure_path
 
-    def safe_ensure_path(self_unused, path, acl=None):
+    def safe_ensure_path(_self, path, acl=None):
         """Safe wrapper around kazoo.client.ensure_path"""
         return ensure_path(path, acl=make_default_acl(acl))
 
@@ -157,7 +157,7 @@ def make_safe_set_acls(zkclient):
     """Makes a wrapper for kazoo.client.set_acls enforcing default acl."""
     set_acls = zkclient.set_acls
 
-    def safe_set_acls(self_unused, path, acls, version=-1):
+    def safe_set_acls(_self, path, acls, version=-1):
         """Safe wrapper around kazoo.client.set_acls"""
         return set_acls(path, make_default_acl(acls), version=version)
 
@@ -333,8 +333,7 @@ class SequenceNodeWatch(object):
             if self.include_data:
                 data, stat = self.zkclient.get(fullpath)
             self.func(fullpath, data, stat)
-        # pylint: disable=W0702
-        except:
+        except Exception:  # pylint: disable=W0703
             _LOGGER.critical('Unexpected error: %s', sys.exc_info()[0])
 
     def on_child(self, event):

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,10 +39,12 @@ source-dir = doc/source
 
 
 ###############################################################################
-[pep8]
+[pycodestyle]
 show_source = True
 show_pep8 = True
 count = True
+# E402: Import not at top of file
+ignore = E402
 
 
 ###############################################################################

--- a/tests/api/allocation_test.py
+++ b/tests/api/allocation_test.py
@@ -65,5 +65,6 @@ class ApiAllocationTest(unittest.TestCase):
              'memory': '1G'},
         )
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/api/schema_test.py
+++ b/tests/api/schema_test.py
@@ -457,5 +457,6 @@ class ApiSchemaTest(unittest.TestCase):
         _fail(api.create, 'foo.bla', _patch(good, '/count', 1001))
         _fail(api.create, 'foo.bla', _patch(good, '/count', '1'))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/appcfg/abort_test.py
+++ b/tests/appcfg/abort_test.py
@@ -109,5 +109,6 @@ class AppCfgAbortTest(unittest.TestCase):
             ),
         )
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/appcfg/manifest_test.py
+++ b/tests/appcfg/manifest_test.py
@@ -414,5 +414,6 @@ class AppCfgManifestTest(unittest.TestCase):
         with self.assertRaises(exc.InvalidInputError):
             app_manifest.load(self.tm_env, event_filename0, 'linux')
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/apptrace/zk_test.py
+++ b/tests/apptrace/zk_test.py
@@ -25,12 +25,6 @@ class AppTraceZKTest(mockzk.MockZookeeperTestCase):
     """Mock test for treadmill.apptrace.
     """
 
-    def setUp(self):
-        super(AppTraceZKTest, self).setUp()
-
-    def tearDown(self):
-        super(AppTraceZKTest, self).tearDown()
-
     @mock.patch('kazoo.client.KazooClient.delete', mock.Mock())
     @mock.patch('kazoo.client.KazooClient.create', mock.Mock())
     @mock.patch('kazoo.client.KazooClient.exists', mock.Mock())

--- a/tests/cgroups_test.py
+++ b/tests/cgroups_test.py
@@ -354,5 +354,6 @@ class CGroupsTest(unittest.TestCase):
 
         self.assertEqual(res, ['a'])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cleanup_test.py
+++ b/tests/cleanup_test.py
@@ -291,5 +291,6 @@ class CleanupTest(unittest.TestCase):
             mock.call('proid.app#0000000000001')
         ])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cli/common_test.py
+++ b/tests/cli/common_test.py
@@ -37,5 +37,6 @@ class CommonTest(unittest.TestCase):
             }
         )
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/discovery_test.py
+++ b/tests/discovery_test.py
@@ -22,12 +22,6 @@ from treadmill import discovery
 class DiscoveryTest(mockzk.MockZookeeperTestCase):
     """Mock test for treadmill.appwatch."""
 
-    def setUp(self):
-        super(DiscoveryTest, self).setUp()
-
-    def tearDown(self):
-        super(DiscoveryTest, self).tearDown()
-
     @mock.patch('treadmill.zkutils.connect', mock.Mock(
         return_value=kazoo.client.KazooClient()))
     @mock.patch('kazoo.client.KazooClient.get', mock.Mock(

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -18,15 +18,10 @@ import unittest
 import tests.treadmill_test_deps  # pylint: disable=W0611
 
 import mock
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 import treadmill
 import treadmill.fs
+import treadmill.subproc
 
 if sys.platform.startswith('linux'):
     import treadmill.fs.linux
@@ -337,7 +332,7 @@ Directory Hash Seed:      20c6af65-0208-4e71-99cb-d5532c02e3b8
         treadmill.subproc.check_output.reset_mock()
 
         treadmill.subproc.check_output.side_effect = (
-            subprocess.CalledProcessError(1, 'command', 'some error')
+            treadmill.subproc.CalledProcessError(1, 'command', 'some error')
         )
 
         self.assertEqual(

--- a/tests/iptables_test.py
+++ b/tests/iptables_test.py
@@ -14,16 +14,11 @@ import unittest
 import tests.treadmill_test_deps  # pylint: disable=W0611
 
 import mock
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 import treadmill
 from treadmill import firewall
 from treadmill import iptables
+from treadmill import subproc
 
 
 class IptablesTest(unittest.TestCase):
@@ -113,7 +108,7 @@ class IptablesTest(unittest.TestCase):
         # pylint: disable=protected-access
         treadmill.iptables._iptables_restore.side_effect = [
             None,
-            subprocess.CalledProcessError(2, 'failed'),
+            subproc.CalledProcessError(2, 'failed'),
             None,
         ]
 
@@ -237,7 +232,7 @@ class IptablesTest(unittest.TestCase):
     def test_delete_dnat_rule_nonexist(self):
         """Test dnat rule deleting when the rule does not exist."""
         treadmill.subproc.check_call.side_effect = \
-            subprocess.CalledProcessError(returncode=1, output='', cmd='')
+            subproc.CalledProcessError(returncode=1, output='', cmd='')
 
         iptables.delete_dnat_rule(
             firewall.DNATRule(proto='tcp',
@@ -620,7 +615,7 @@ class IptablesTest(unittest.TestCase):
         treadmill.subproc.check_call.reset_mock()
         treadmill.subproc.check_call.return_value = 1
         treadmill.subproc.check_call.side_effect = \
-            subprocess.CalledProcessError(returncode=1, cmd='failed conntrack')
+            subproc.CalledProcessError(returncode=1, cmd='failed conntrack')
 
         treadmill.iptables.flush_cnt_conntrack_table('4.4.4.4')
 
@@ -643,7 +638,7 @@ class IptablesTest(unittest.TestCase):
         treadmill.subproc.check_call.reset_mock()
         treadmill.subproc.check_call.return_value = 1
         treadmill.subproc.check_call.side_effect = \
-            subprocess.CalledProcessError(returncode=1, cmd='failed conntrack')
+            subproc.CalledProcessError(returncode=1, cmd='failed conntrack')
 
         treadmill.iptables.flush_pt_conntrack_table('4.4.4.4')
 

--- a/tests/journal_test.py
+++ b/tests/journal_test.py
@@ -49,13 +49,14 @@ class ListJournaler(jplugin.BaseJournaler):
         self.journals = []
 
     def _log_exec(self, step, transaction_id,
-                  resource, action, pk, payload,
+                  resource, action, rsrc_id, payload,
                   user, timestamp):
 
         self.journals.append(
             (
                 '%s,%s,%s,%s,%s,%s,%0.2f' % (
-                    step, transaction_id, resource, action, pk, user, timestamp
+                    step, transaction_id, resource, action,
+                    rsrc_id, user, timestamp
                 ),
                 payload
             )

--- a/tests/localdiskutils_test.py
+++ b/tests/localdiskutils_test.py
@@ -6,22 +6,16 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 # Disable W0611: Unused import
 import tests.treadmill_test_deps  # pylint: disable=W0611
 
 import mock
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 import treadmill
 from treadmill import localdiskutils
+from treadmill import subproc
 
 
 class LocalDiskTest(unittest.TestCase):
@@ -97,7 +91,7 @@ class LocalDiskTest(unittest.TestCase):
         img_size = 42
 
         treadmill.lvm.vgactivate.side_effect = \
-            subprocess.CalledProcessError(returncode=5, cmd='lvm')
+            subproc.CalledProcessError(returncode=5, cmd='lvm')
         mock_init_blkdev = treadmill.localdiskutils.init_block_dev
         mock_init_blkdev.return_value = '/dev/test'
         treadmill.lvm.lvsdisplay.return_value = []
@@ -130,7 +124,7 @@ class LocalDiskTest(unittest.TestCase):
         block_dev = '/dev/test'
 
         treadmill.lvm.vgactivate.side_effect = \
-            subprocess.CalledProcessError(returncode=5, cmd='lvm')
+            subproc.CalledProcessError(returncode=5, cmd='lvm')
         treadmill.lvm.lvsdisplay.return_value = []
 
         localdiskutils.setup_device_lvm(block_dev)

--- a/tests/master_test.py
+++ b/tests/master_test.py
@@ -1261,5 +1261,6 @@ class MasterTest(mockzk.MockZookeeperTestCase):
         self.assertFalse(treadmill.zkutils.ensure_exists.called)
         self.assertFalse(treadmill.zkutils.put.called)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -19,16 +19,11 @@ import unittest
 import tests.treadmill_test_deps  # pylint: disable=W0611
 
 import mock
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 import treadmill
 from treadmill import fs
 from treadmill import monitor
+from treadmill import subproc
 from treadmill import supervisor
 
 
@@ -149,7 +144,7 @@ class MonitorTest(unittest.TestCase):
         )
         mock_pol_inst = mock_policy.return_value
         treadmill.supervisor.wait_service.side_effect = [
-            subprocess.CalledProcessError(supervisor.ERR_TIMEOUT, 's6-svwait'),
+            subproc.CalledProcessError(supervisor.ERR_TIMEOUT, 's6-svwait'),
             None,
         ]
 
@@ -219,7 +214,7 @@ class MonitorTest(unittest.TestCase):
         )
         mock_pol_inst = mock_policy.return_value
         treadmill.supervisor.wait_service.side_effect = (
-            subprocess.CalledProcessError(supervisor.ERR_NO_SUP, 's6-svwait')
+            subproc.CalledProcessError(supervisor.ERR_NO_SUP, 's6-svwait')
         )
 
         mon._bring_up(mock_pol_inst.service)

--- a/tests/newnet_test.py
+++ b/tests/newnet_test.py
@@ -160,5 +160,6 @@ class NewnetTest(unittest.TestCase):
             ]
         )
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/runtime_test.py
+++ b/tests/runtime_test.py
@@ -272,5 +272,6 @@ class RuntimeTest(unittest.TestCase):
         self.assertFalse(os.path.exists(file1))
         self.assertTrue(os.path.exists(file2))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -1638,5 +1638,6 @@ class ShapeTest(unittest.TestCase):
         app = scheduler.Application('foo', 11, [5, 5, 5], 'bar1')
         self.assertTrue(placement_tracker.feasible(app))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/services/localdisk_service_test.py
+++ b/tests/services/localdisk_service_test.py
@@ -17,15 +17,10 @@ import unittest
 import tests.treadmill_test_deps  # pylint: disable=W0611
 
 import mock
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 import treadmill
 from treadmill import localdiskutils
+from treadmill import subproc
 from treadmill.services import localdisk_service
 
 
@@ -316,7 +311,7 @@ class LocalDiskServiceTest(unittest.TestCase):
         request_id = 'myproid.test-0-ID1234'
         # trying to find the LV fails
         treadmill.lvm.lvdisplay.side_effect = (
-            subprocess.CalledProcessError(returncode=5, cmd='lvm'),
+            subproc.CalledProcessError(returncode=5, cmd='lvm'),
         )
 
         svc.on_delete_request(request_id)
@@ -349,11 +344,11 @@ class LocalDiskServiceTest(unittest.TestCase):
         request_id = 'myproid.test-0-ID1234'
         # trying to lvremote fails
         treadmill.lvm.lvremove.side_effect = (
-            subprocess.CalledProcessError(returncode=5, cmd='lvm'),
+            subproc.CalledProcessError(returncode=5, cmd='lvm'),
         )
 
         self.assertRaises(
-            subprocess.CalledProcessError,
+            subproc.CalledProcessError,
             svc.on_delete_request,
             request_id
         )
@@ -416,7 +411,7 @@ class LocalDiskServiceTest(unittest.TestCase):
         # pylint: disable=W0212
 
         treadmill.lvm.vgactivate.side_effect = [
-            subprocess.CalledProcessError(returncode=5, cmd='lvm'),
+            subproc.CalledProcessError(returncode=5, cmd='lvm'),
             0,
         ]
 
@@ -442,7 +437,7 @@ class LocalDiskServiceTest(unittest.TestCase):
         # pylint: disable=W0212
 
         localdiskutils.loop_dev_for.side_effect = [
-            subprocess.CalledProcessError(returncode=1, cmd='losetup'),
+            subproc.CalledProcessError(returncode=1, cmd='losetup'),
             '/dev/test'
         ]
 
@@ -477,6 +472,7 @@ class LocalDiskServiceTest(unittest.TestCase):
             '/bar/foo',
             10 * 1024**3 - 2 * 1024**3,  # 10G free - 2G reserve
         )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/services/network_service_test.py
+++ b/tests/services/network_service_test.py
@@ -15,14 +15,9 @@ import unittest
 import tests.treadmill_test_deps  # pylint: disable=W0611
 
 import mock
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 import treadmill
+from treadmill import subproc
 from treadmill.services import network_service
 
 
@@ -239,7 +234,7 @@ class NetworkServiceTest(unittest.TestCase):
         treadmill.services.network_service._device_info.side_effect = \
             lambda dev: {'alias': 'reqid_%s' % dev}
         treadmill.netdev.link_set_up.side_effect = [
-            subprocess.CalledProcessError('any', 'how'),
+            subproc.CalledProcessError('any', 'how'),
             None,
         ]
         mock_vipmgr_inst = mock_vipmgr.return_value

--- a/tests/spawn/cleanup_test.py
+++ b/tests/spawn/cleanup_test.py
@@ -58,5 +58,6 @@ class CleanupTest(unittest.TestCase):
         treadmill.spawn.cleanup.Cleanup._on_created \
                  .assert_called_with('/does/not/exist/cleanup/job1')
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/spawn/tree_test.py
+++ b/tests/spawn/tree_test.py
@@ -44,5 +44,6 @@ class TreeTest(unittest.TestCase):
         self.assertEqual(6, utils.create_script.call_count)
         self.assertEqual(2, shutil.rmtree.call_count)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/sproc/appmonitor_test.py
+++ b/tests/sproc/appmonitor_test.py
@@ -181,5 +181,6 @@ class AppMonitorTest(unittest.TestCase):
         self.assertTrue(restclient.post.called)
         self.assertNotIn('foo.bar', state['delayed'])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/sproc/metrics_test.py
+++ b/tests/sproc/metrics_test.py
@@ -143,5 +143,6 @@ class MetricsTest(unittest.TestCase):
             ]
         )
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/supervisor_test.py
+++ b/tests/supervisor_test.py
@@ -17,18 +17,10 @@ import unittest
 import tests.treadmill_test_deps  # pylint: disable=W0611
 
 import mock
-import six
-
-if six.PY2 and os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=import-error
-else:
-    import subprocess  # pylint: disable=wrong-import-order
 
 import treadmill
 from treadmill import supervisor
-
-# Disable: C0103 because names are too long
-# pylint: disable=C0103
+from treadmill import subproc
 
 
 def _strip(content):
@@ -148,7 +140,7 @@ class SupervisorTest(unittest.TestCase):
         treadmill.subproc.check_call.assert_called_with(['s6_svok', self.root])
 
         treadmill.subproc.check_call.side_effect = \
-            subprocess.CalledProcessError(1, 's6_svok')
+            subproc.CalledProcessError(1, 's6_svok')
         self.assertFalse(supervisor.is_supervised(self.root))
         treadmill.subproc.check_call.assert_called_with(['s6_svok', self.root])
 
@@ -184,9 +176,9 @@ class SupervisorTest(unittest.TestCase):
         )
 
         treadmill.subproc.check_call.side_effect = \
-            subprocess.CalledProcessError(1, 's6_svc')
+            subproc.CalledProcessError(1, 's6_svc')
         self.assertRaises(
-            subprocess.CalledProcessError,
+            subproc.CalledProcessError,
             supervisor.control_service,
             self.root,
             supervisor.ServiceControlAction.down
@@ -219,7 +211,7 @@ class SupervisorTest(unittest.TestCase):
         # shutdown service timeouts
         treadmill.subproc.check_call.reset_mock()
         supervisor.wait_service.side_effect = \
-            subprocess.CalledProcessError(99, 's6_svwait')
+            subproc.CalledProcessError(99, 's6_svwait')
 
         res = supervisor.control_service(
             self.root, supervisor.ServiceControlAction.down,
@@ -239,9 +231,9 @@ class SupervisorTest(unittest.TestCase):
         # shutdown unsupervised service
         treadmill.subproc.check_call.reset_mock()
         treadmill.subproc.check_call.side_effect = \
-            subprocess.CalledProcessError(100, 's6_svc')
+            subproc.CalledProcessError(100, 's6_svc')
 
-        with self.assertRaises(subprocess.CalledProcessError):
+        with self.assertRaises(subproc.CalledProcessError):
             supervisor.control_service(
                 self.root, supervisor.ServiceControlAction.down,
                 wait=supervisor.ServiceWaitAction.down,
@@ -293,8 +285,8 @@ class SupervisorTest(unittest.TestCase):
 
         treadmill.subproc.check_call.reset_mock()
         treadmill.subproc.check_call.side_effect = \
-            subprocess.CalledProcessError(99, 's6_svwait')
-        with self.assertRaises(subprocess.CalledProcessError):
+            subproc.CalledProcessError(99, 's6_svwait')
+        with self.assertRaises(subproc.CalledProcessError):
             supervisor.wait_service(
                 self.root, supervisor.ServiceWaitAction.really_down
             )
@@ -302,8 +294,9 @@ class SupervisorTest(unittest.TestCase):
             ['s6_svwait', '-D', self.root]
         )
 
+    # Disable: C0103 because names are too long
     @mock.patch('treadmill.supervisor.is_supervised', mock.Mock())
-    def test_ensure_not_supervised_not_running(self):
+    def test_ensure_not_supervised_not_running(self):  # pylint: disable=C0103
         """Tests ensuring a service and its logs are down when they already
         are not supervised.
         """
@@ -348,15 +341,16 @@ class SupervisorTest(unittest.TestCase):
 
         self.assertEqual(2, treadmill.supervisor.is_supervised.call_count)
 
+    # Disable: C0103 because names are too long
     @mock.patch('treadmill.supervisor.is_supervised', mock.Mock())
     @mock.patch('treadmill.supervisor.control_service', mock.Mock())
     @mock.patch('time.sleep', mock.Mock())
-    def test_ensure_not_supervised_failed(self):
+    def test_ensure_not_supervised_failed(self):  # pylint: disable=C0103
         """Tests when a service fails to be brought down.
         """
         treadmill.supervisor.is_supervised.return_value = True
         treadmill.supervisor.control_service.side_effect = \
-            subprocess.CalledProcessError(1, '')
+            subproc.CalledProcessError(1, '')
 
         with self.assertRaises(Exception):
             supervisor.ensure_not_supervised(self.root)

--- a/tests/websocket/api/trace_test.py
+++ b/tests/websocket/api/trace_test.py
@@ -130,5 +130,6 @@ class WSRunningAPITest(unittest.TestCase):
             payload='xxx'
         )
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 * encode prodperim rule before compressing
 * pylint: fix new warnings
 * style python: Bump tooling
 * Leverage tmpfs /run mount for all containers using zk2fs.
 * Make paged search optional in admin.get
 * iptables: Use fixed length set name in atomic update
 * cleanup subprocess/subproc imports