### PR TITLE
Sync with 2018.02.27-2

### DIFF
--- a/lib/python/treadmill/appcfgmgr.py
+++ b/lib/python/treadmill/appcfgmgr.py
@@ -40,6 +40,7 @@ import six
 from treadmill import appenv
 from treadmill import appcfg
 from treadmill import exc
+from treadmill import eventmgr
 from treadmill import fs
 from treadmill import dirwatch
 from treadmill import logcontext as lc
@@ -143,7 +144,7 @@ class AppCfgMgr(object):
         """
         instance_name = os.path.basename(event_file)
 
-        if instance_name == '.seen':
+        if instance_name == eventmgr.READY_FILE:
             self._first_sync()
             return
 
@@ -163,7 +164,7 @@ class AppCfgMgr(object):
         """
         instance_name = os.path.basename(event_file)
 
-        if instance_name == '.seen':
+        if instance_name == eventmgr.READY_FILE:
             self._first_sync()
             return
 
@@ -194,7 +195,7 @@ class AppCfgMgr(object):
             ``str``
         """
         instance_name = os.path.basename(event_file)
-        if instance_name == '.seen':
+        if instance_name == eventmgr.READY_FILE:
             _LOGGER.info('Cache folder not ready.'
                          ' Stopping processing of events.')
             self._is_active = False

--- a/lib/python/treadmill/rest/__init__.py
+++ b/lib/python/treadmill/rest/__init__.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import abc
 import logging
+import os
 import tornado.httpserver
 import tornado.ioloop
 import tornado.web
@@ -16,6 +17,7 @@ import tornado.netutil
 
 import flask
 
+from treadmill import fs
 from treadmill import plugin_manager
 
 
@@ -150,6 +152,7 @@ class UdsRestServer(RestServer):
 
     def _setup_endpoint(self, http_server):
         """Setup the http server endpoint."""
+        fs.mkdir_safe(os.path.dirname(self.socket), mode=0o755)
         unix_socket = tornado.netutil.bind_unix_socket(self.socket,
                                                        backlog=self.backlog)
         if self.workers != 1:

--- a/lib/python/treadmill/runtime/docker2/_manifest.py
+++ b/lib/python/treadmill/runtime/docker2/_manifest.py
@@ -54,7 +54,10 @@ def _get_docker_run_cmd(username, unique_id, image, command=None):
     ]
 
     tpl = (
-        'exec {tm} sproc docker --unique_id {unique_id} --user {uid}:{gid}'
+        'exec {tm} sproc docker'
+        ' --unique_id {unique_id}'
+        ' --user {uid}:{gid}'
+        ' --envdirs /env,/services/{unique_id}/env'
         ' --image {image}'
     )
 
@@ -109,7 +112,7 @@ def _transform_services(manifest):
 
 def _get_docker_registry(_tm_env):
     # TODO get registry from cell_config.yml
-    return 'registry:5000'
+    return 'lab-repo.msdev.ms.com:5000'
 
 
 def _add_dockerd_services(manifest, tm_env):

--- a/lib/python/treadmill/runtime/docker2/image/native.py
+++ b/lib/python/treadmill/runtime/docker2/image/native.py
@@ -519,7 +519,7 @@ class NativeImage(_image_base.Image):
         create_supervision_tree(
             self.tm_env, container_dir, root_dir, app,
             cgroups_path=cgroups.makepath(
-                'memory', 'docker'  # XXX: Why "docker"? Issues with shutdown?
+                'memory', cgrp
             )
         )
         create_overlay(self.tm_env, container_dir, root_dir, app)

--- a/lib/python/treadmill/sproc/docker.py
+++ b/lib/python/treadmill/sproc/docker.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import socket
 import sys
 import time
 
@@ -18,6 +19,7 @@ import six
 from treadmill import cli
 from treadmill import exc
 from treadmill import utils
+from treadmill import supervisor
 
 from treadmill.appcfg import abort as app_abort
 
@@ -31,12 +33,17 @@ def _get_name(image, unique_id):
     return '{}-{}'.format(image, unique_id)
 
 
-def _get_environs():
-    """Foward all treadmill related environ to container
+def _read_environ(envdirs):
+    """Read a list of environ directories and return a full envrion ``dict``.
+
+    :returns:
+        ``dict`` - Environ dictionary.
     """
-    return {key: val
-            for key, val in six.iteritems(os.environ)
-            if key[:10] == 'TREADMILL_'}
+    environ = {}
+    for envdir in envdirs:
+        environ.update(supervisor.read_environ_dir(envdir))
+
+    return environ
 
 
 def _create_container(client, image, cmd, name, **args):
@@ -47,7 +54,6 @@ def _create_container(client, image, cmd, name, **args):
     container_args = {
         'image': image,
         'name': name,
-        'environment': _get_environs(),
         'command': list(cmd),
         'detach': True,
         'stdin_open': True,
@@ -80,14 +86,15 @@ def _transform_volumes(volumes):
     """
     dict_volume = {}
     for volume in volumes:
-        items = volume.split(':')
-
-        # Example format: /var/tmp:/dest_var_tmp:rw =>
-        # {'/var/tmp': {'bind': '/dest_var_tmp', 'mode': 'rw}}
-        if len(items) == 2:
-            dict_volume[items[0]] = {'bind': items[1], 'mode': 'rw'}
-        else:
-            dict_volume[items[0]] = {'bind': items[1], 'mode': items[2]}
+        # Example format:
+        #   /var/tmp:/dest_var_tmp:rw => {
+        #       /var/tmp': {
+        #           'bind': '/dest_var_tmp',
+        #           'mode': 'rw
+        #       }
+        #   }
+        (target, source, mode) = volume.split(':', 2)
+        dict_volume[target] = {'bind': source, 'mode': mode}
 
     return dict_volume
 
@@ -131,6 +138,9 @@ class DockerSprocClient(object):
             if 'volumes' in args:
                 args['volumes'] = _transform_volumes(args['volumes'])
 
+            if 'envdirs' in args:
+                args['environment'] = _read_environ(args.pop('envdirs'))
+
             container = _create_container(
                 client, image, cmd, name, **args
             )
@@ -142,18 +152,31 @@ class DockerSprocClient(object):
 
         container.start()
         container.reload()
+        logs_gen = container.logs(
+            stdout=True,
+            stderr=True,
+            stream=True,
+            follow=True
+        )
 
         _LOGGER.info('Container %s is running', name)
-        for output in container.logs(
-                stdout=True, stderr=True, stream=True, follow=True):
-            sys.stderr.write(output)
+        while container.status == 'running':
+            try:
+                for log_lines in logs_gen:
+                    sys.stderr.write(log_lines)
+            except socket.error:
+                pass
 
-            if output == '':
-                container.reload()
+            container.reload()
 
-            if container.status != 'running':
-                rc = container.wait()
-                utils.sys_exit(rc)
+        rc = container.wait()
+        if os.WIFSIGNALED(rc):
+            # Process died with a signal in docker
+            sig = os.WTERMSIG(rc)
+            os.kill(os.getpid(), sig)
+
+        else:
+            utils.sys_exit(os.WEXITSTATUS(rc))
 
 
 def init():
@@ -162,12 +185,16 @@ def init():
     @click.command()
     @click.option('--image', required=True, help='docker image')
     @click.option('--unique_id', required=True, help='uniq_id for container')
-    @click.option('--user', required=False, help='userid')
-    @click.option('--read-only', is_flag=True, default=True,
-                  help='image read only')
-    @click.option('--volume', type=cli.LIST, required=False)
+    @click.option('--user', required=False,
+                  help='userid in the form UID:GID')
+    @click.option('--envdirs', type=cli.LIST, required=False, default=[],
+                  help='List of environ directory to pass into the container.')
+    @click.option('--read-only', is_flag=True, default=False,
+                  help='Mount the docker image read-only')
+    @click.option('--volume', multiple=True, required=False,
+                  help='Specify each volume as TARGET:SOURCE:MODE')
     @click.argument('cmd', nargs=-1)
-    def configure(image, cmd, user, unique_id, read_only, volume):
+    def configure(image, cmd, user, envdirs, unique_id, read_only, volume):
         """Configure local manifest and schedule app to run."""
         service_client = DockerSprocClient()
         service_client.run(
@@ -175,6 +202,7 @@ def init():
             image, cmd, unique_id,
             # optional parameters
             user=user,
+            envdirs=envdirs,
             read_only=read_only,
             volumes=volume,
         )

--- a/lib/python/treadmill/supervisor/__init__.py
+++ b/lib/python/treadmill/supervisor/__init__.py
@@ -48,11 +48,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import json
-import os
-import logging
-import time
 import enum
+import errno
+import json
+import logging
+import os
+import time
 
 import jinja2
 
@@ -220,6 +221,21 @@ def create_environ_dir(env_dir, env, update=False):
         env_dir, env,
         update=update
     )
+
+
+def read_environ_dir(env_dir):
+    """Read an existing environ directory into a ``dict``.
+
+    :returns:
+        ``dict`` - Dictionary of environment variables.
+    """
+    try:
+        return supervisor_utils.environ_dir_read(env_dir)
+    except (OSError, IOError) as err:
+        if err.errno == errno.ENOENT:
+            return {}
+        else:
+            raise
 
 
 # Disable W0613: Unused argument 'kwargs' (for s6/winss compatibility)
@@ -562,22 +578,23 @@ LongrunService = sup_impl.LongrunService
 ServiceType = _service_base.ServiceType
 
 __all__ = [
-    'ScanDir',
-    'LongrunService',
-    'ServiceType',
     'ERR_COMMAND',
     'ERR_NO_SUP',
     'EXITS_DIR',
-    'create_environ_dir',
-    'ServiceWaitAction',
+    'LongrunService',
+    'ScanDir',
     'ServiceControlAction',
+    'ServiceType',
+    'ServiceWaitAction',
     'SvscanControlAction',
-    'open_service',
+    'control_service',
+    'control_svscan',
+    'create_environ_dir',
     'create_scan_dir',
     'create_service',
     'is_supervised',
-    'control_service',
-    'control_svscan',
+    'open_service',
+    'read_environ_dir',
     'wait_service',
 ]
 

--- a/lib/python/treadmill/supervisor/_utils.py
+++ b/lib/python/treadmill/supervisor/_utils.py
@@ -217,6 +217,7 @@ def script_write(filename, script):
     with io.open(filename, 'w') as f:
         for chunk in script:
             f.write(chunk)
+        f.write('\n')
         if os.name == 'posix':
             os.fchmod(f.fileno(), 0o755)
 

--- a/tests/eventmgr_test.py
+++ b/tests/eventmgr_test.py
@@ -26,27 +26,28 @@ from treadmill import eventmgr
 from treadmill import yamlwrapper as yaml
 
 
-class MockEvent(object):
-    """Mock Kazoo Event object."""
+class MockEventObject(object):
+    """Mock event object."""
 
-    def __init__(self, etype='ANY'):
-        self.type = etype
+    def __init__(self):
+        self._is_set = False
+
+    def clear(self):
+        """Clear the internal flag to false."""
+        self._is_set = False
+
+    def set(self):
+        """Set the internal flag to true."""
+        self._is_set = True
+
+    def is_set(self):
+        """Return true if the internal flag is set to true, false otherwise."""
+        return self._is_set
 
 
-class MockStat(object):
-    """Mock ZnodeStat for convinience."""
-    # C0103: Invalid name "ephemeralOwner"
-    # pylint: disable=C0103
-    def __init__(self, created=0, modified=None, ephemeralOwner=42):
-        self.created = created
-        self.last_modified = created
-        self.ctime = self.created * 1000
-        if modified is not None:
-            self.last_modified = modified
-        else:
-            self.last_modified = created
-        self.mtime = self.last_modified * 1000
-        self.ephemeralOwner = ephemeralOwner
+def mock_event_object():
+    """Return mock event object."""
+    return MockEventObject()
 
 
 class EventMgrTest(mockzk.MockZookeeperTestCase):
@@ -70,40 +71,88 @@ class EventMgrTest(mockzk.MockZookeeperTestCase):
         if self.root and os.path.isdir(self.root):
             shutil.rmtree(self.root)
 
-    @unittest.skip('Broken fixme')
-    @mock.patch('treadmill.eventmgr.EventMgr._cache_notify', mock.Mock())
-    @mock.patch('treadmill.zkutils.connect', autospec=True)
-    def test_run(self, mock_connect):
-        """.
+    @mock.patch('time.sleep', mock.Mock())
+    @mock.patch('treadmill.context.GLOBAL.zk', mock.Mock())
+    def test_run(self):
+        """Test EventMgr run method.
         """
-        # Access to a protected member _cache_notify of a client class
-        # pylint: disable=W0212
-        self.evmgr.run()
+        mock_zkclient = mock.Mock()
+        context.GLOBAL.zk.conn = mock_zkclient
+
+        mock_data_watch = mock.Mock(
+            side_effect=lambda func: func({'valid_until': 123.0}, None, None)
+        )
+
+        mock_children_watch = mock.Mock(
+            side_effect=lambda func: func(['foo.bar#0'])
+        )
+
+        mock_zkclient.get.return_value = ('{}', None)
+        mock_zkclient.DataWatch.return_value = mock_data_watch
+        mock_zkclient.ChildrenWatch.return_value = mock_children_watch
+        mock_zkclient.handler.event_object.side_effect = mock_event_object
+
+        self.evmgr.run(once=True)
+
+        self.assertTrue(os.path.exists(os.path.join(self.cache, '.ready')))
+        self.assertTrue(os.path.exists(os.path.join(self.cache, 'foo.bar#0')))
 
         mock_watchdog = self.evmgr.tm_env.watchdogs
         mock_watchdog.create.assert_called_with(
             content=mock.ANY,
-            name='svc:EventMgr',
-            timeout='60s'
+            name='svc-EventMgr',
+            timeout='120s'
         )
         mock_watchdog_lease = mock_watchdog.create.return_value
         mock_watchdog_lease.heartbeat.assert_called_with()
 
-        mock_zkconnect = mock_connect.return_value
-        mock_zkconnect.handler.event_object.assert_called_with()
+        # The main loop terminates immediately
+        mock_watchdog_lease.remove.assert_called_with()
 
-        mock_seen = mock_zkconnect.handler.event_object.return_value
-        mock_seen.clear.assert_called_with()
+    @mock.patch('time.sleep', mock.Mock())
+    @mock.patch('treadmill.context.GLOBAL.zk', mock.Mock())
+    def test_run_not_present(self):
+        """Test EventMgr run method - no server presence.
+        """
+        mock_zkclient = mock.Mock()
+        context.GLOBAL.zk.conn = mock_zkclient
 
-        treadmill.eventmgr.EventMgr._cache_notify.assert_called_with()
-
-        mock_zkconnect.DataWatch.assert_called_with(
-            '/some/path',
+        mock_data_watch = mock.Mock(
+            side_effect=lambda func: func(None, None, None)
         )
 
-        # The main loop terminates immediately
+        mock_children_watch = mock.Mock(
+            side_effect=lambda func: func(['foo.bar#0'])
+        )
 
-        mock_watchdog_lease.remove.assert_called_with()
+        mock_zkclient.get.return_value = ('{}', None)
+        mock_zkclient.DataWatch.return_value = mock_data_watch
+        mock_zkclient.ChildrenWatch.return_value = mock_children_watch
+        mock_zkclient.handler.event_object.side_effect = mock_event_object
+
+        self.evmgr.run(once=True)
+
+        self.assertFalse(os.path.exists(os.path.join(self.cache, '.ready')))
+        self.assertTrue(os.path.exists(os.path.join(self.cache, 'foo.bar#0')))
+
+    @mock.patch('time.sleep', mock.Mock())
+    @mock.patch('treadmill.context.GLOBAL.zk', mock.Mock())
+    def test_run_not_synchronized(self):
+        """Test EventMgr run method - apps not synchronized.
+        """
+        mock_zkclient = mock.Mock()
+        context.GLOBAL.zk.conn = mock_zkclient
+
+        mock_data_watch = mock.Mock(
+            side_effect=lambda func: func({'valid_until': 123.0}, None, None)
+        )
+
+        mock_zkclient.DataWatch.return_value = mock_data_watch
+        mock_zkclient.handler.event_object.side_effect = mock_event_object
+
+        self.evmgr.run(once=True)
+
+        self.assertFalse(os.path.exists(os.path.join(self.cache, '.ready')))
 
     @mock.patch('treadmill.zkutils.get', mock.Mock())
     def test__cache(self):
@@ -213,6 +262,18 @@ class EventMgrTest(mockzk.MockZookeeperTestCase):
         with io.open(appcache) as f:
             data = yaml.load(stream=f)
             self.assertEqual(data['identity'], 1)
+
+    def test__cache_notify(self):
+        """Test sending a cache status notification event."""
+        # Access to a protected member _cache_notify of a client class
+        # pylint: disable=W0212
+        ready_file = os.path.join(self.cache, '.ready')
+
+        self.evmgr._cache_notify(True)
+        self.assertTrue(os.path.exists(ready_file))
+
+        self.evmgr._cache_notify(False)
+        self.assertFalse(os.path.exists(ready_file))
 
 
 if __name__ == '__main__':

--- a/tests/rest/__init__.py
+++ b/tests/rest/__init__.py
@@ -1,1 +1,39 @@
 """Tests for treadmill.rest.*"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os.path
+import tempfile
+import unittest
+from unittest import mock
+
+import tests.treadmill_test_deps  # pylint: disable=W0611
+
+from treadmill import rest
+
+
+# W0212: Access to a protected member of a client class
+# pylint: disable=W0212
+class UdsRestServerTest(unittest.TestCase):
+    """Test for treadmill.rest.UdsRestServer."""
+
+    def test_udsrestsrv(self):
+        """Dummy test."""
+        socket = os.path.join(
+            tempfile.gettempdir(), 'no', 'such', 'dir', 'foo.sock'
+        )
+        rest_server = rest.UdsRestServer(socket)
+
+        # not yet existing socket w/ containing dir should be created
+        rest_server._setup_endpoint(mock.Mock())
+        self.assertTrue(os.path.exists(socket))
+
+        # shouldn't fail if the containing dir already exists
+        rest_server._setup_endpoint(mock.Mock())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/runtime/docker2/manifest_test.py
+++ b/tests/runtime/docker2/manifest_test.py
@@ -55,9 +55,15 @@ class Docker2RuntimeManifestTest(unittest.TestCase):
         )
         self.assertEqual(
             cmd,
-            ('exec /path/to/treadcmill34 sproc docker --unique_id foo '
-             '--user 274091:19290 --image testwt2 '
-             '--volume /var/tmp:/var/tmp:rw --volume /var/spool:/var/spool:rw')
+            (
+                'exec /path/to/treadcmill34 sproc docker'
+                ' --unique_id foo'
+                ' --user 274091:19290'
+                ' --envdirs /env,/services/foo/env'
+                ' --image testwt2'
+                ' --volume /var/tmp:/var/tmp:rw'
+                ' --volume /var/spool:/var/spool:rw'
+            )
         )
 
         cmd = app_manifest._generate_command(
@@ -65,10 +71,17 @@ class Docker2RuntimeManifestTest(unittest.TestCase):
         )
         self.assertEqual(
             cmd,
-            ('exec /path/to/treadcmill34 sproc docker --unique_id foo '
-             '--user 274091:19290 --image testwt2 '
-             '--volume /var/tmp:/var/tmp:rw --volume /var/spool:/var/spool:rw '
-             '-- foo bar')
+            (
+                'exec /path/to/treadcmill34 sproc docker'
+                ' --unique_id foo'
+                ' --user 274091:19290'
+                ' --envdirs /env,/services/foo/env'
+                ' --image testwt2'
+                ' --volume /var/tmp:/var/tmp:rw'
+                ' --volume /var/spool:/var/spool:rw'
+                ' --'
+                ' foo bar'
+            )
         )
 
 


### PR DESCRIPTION
 * Fix admin show pending.
 * rest.UdsRestServer creates the socket's containing dir if not exists.
 * Fix eventmgr cache .seen (now .ready) logic - cache is ready if and only if the server is present and apps are synchronized. Increase watchdog timeout to match appcfgmgr. Fix tests.
 * always add new line to supervisor script
 * Fix builtins import error in py27
 * Fix device busy issue on cgroups setup
 * docker: Pass all environment from manifest into docker container.
 * docker: Default the docker image to RW
 * docker: Fix the mounting of additional volumes
 * cgroup part: Improved logging of cgroup init
 * docker: Parse the process exit status into signal and rc.
 * iptables: resolve more locking issues with iptables 1.4.21
 * docker2: Use the correct cgroup for shutdown.
 * docker: handle timeout exceptions while tracing container logs