### PR TITLE
Santitize generated container name

### DIFF
--- a/lib/python/treadmill/runtime/docker/runtime.py
+++ b/lib/python/treadmill/runtime/docker/runtime.py
@@ -113,6 +113,7 @@ def _create_container(tm_env, conf, client, app):
     client.images.pull(image_name)
 
     name = appcfg.app_unique_name(app)
+    name = name.replace('/', '-')
 
     container_args = {
         'image': image_name,


### PR DESCRIPTION
docker-runc only allows the following characters in container names:
[a-zA-Z0-9][a-zA-Z0-9_.-]

Container names are currently based on the Docker image name, which includes a forward slash as a separator. eg: bretttegartms/hello-world. 

This patch changes the slash to a dash during name generation.  