### PR TITLE
Remove [easy_install] section from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,3 @@ concurency =
 
 [converage:report]
 omit = /ms/dist/*
-
-[easy_install]
-allow_hosts =


### PR DESCRIPTION
It broke setup_wheel_cache.sh, fixed.