### PR TITLE
Add /var/empty/sshd to emptydirs

### DIFF
--- a/lib/python/treadmill/runtime/linux/image/native.py
+++ b/lib/python/treadmill/runtime/linux/image/native.py
@@ -256,6 +256,7 @@ def make_fsroot(root_dir, app):
         '/usr',
         '/var/cache',
         '/var/empty',
+        '/var/empty/sshd',
         '/var/lib',
         '/var/lock',
         '/var/log',


### PR DESCRIPTION
sshd in the Treadmill container runtime requires that this folder exist to start.