### PR TITLE
LDAP server.py str/bytes conversion

### DIFF
--- a/lib/python/treadmill/cli/admin/ldap/server.py
+++ b/lib/python/treadmill/cli/admin/ldap/server.py
@@ -50,7 +50,7 @@ def init():
                 partition = None
             attrs['partition'] = partition
         if data:
-            with io.open(data, 'rb') as fd:
+            with io.open(data, 'r') as fd:
                 attrs['data'] = json.loads(fd.read())
 
         if attrs:


### PR DESCRIPTION
Calling the function results in a TypeError: the JSON object must be str, not 'bytes'