### PR TITLE
Sync with 2018.05.31-3

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,5 +8,6 @@ recursive-include lib/python/treadmill/bootstrap/zookeeper/linux *
 # Treadmill resources
 recursive-include lib/python/treadmill/etc/ldap *
 recursive-include lib/python/treadmill/etc/schema *
+recursive-include lib/python/treadmill/etc/kernel_watchdog_tests *
 recursive-include lib/python/treadmill/logging *.json
 recursive-include lib/python/treadmill/templates *

--- a/lib/python/treadmill/cli/admin/install/tkt_fwd.py
+++ b/lib/python/treadmill/cli/admin/install/tkt_fwd.py
@@ -1,5 +1,6 @@
 """Installs and configures Treadmill tkt-fwd locally.
 """
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tests/runtime/linux/image/native_test.py
+++ b/tests/runtime/linux/image/native_test.py
@@ -189,9 +189,9 @@ class NativeImageTest(unittest.TestCase):
         treadmill.fs.linux.mount_mqueue.assert_called_once_with(
             self.root, '/dev/mqueue'
         )
-
         treadmill.fs.linux.mount_bind.assert_has_calls([
-            mock.call(mock.ANY, '/bin', read_only=True, recursive=True)
+            mock.call(self.root, '/dev/log', read_only=False),
+            mock.call(self.root, '/bin', read_only=True, recursive=True)
         ])
 
     @mock.patch('pwd.getpwnam', mock.Mock(


### PR DESCRIPTION
 * Don't hardcode treadmill preload name.
 * runtime: Bind the system logger into the containers.
 * Add watchdog etc files in train dist
 * bump docker lib version