### PR TITLE
Sync with 2018.06.04-1

### DIFF
--- a/lib/python/treadmill/context.py
+++ b/lib/python/treadmill/context.py
@@ -199,7 +199,6 @@ class ZkContext(object):
     """
 
     __slots__ = (
-        'proid',
         '_context',
         '_conn',
         '_listeners',
@@ -209,7 +208,6 @@ class ZkContext(object):
         self._context = ctx
         self._conn = None
         self._listeners = []
-        self.proid = None
 
     def add_listener(self, listener):
         """Add a listener.
@@ -238,7 +236,6 @@ class ZkContext(object):
 
         _LOGGER.debug('Connecting to Zookeeper %s', self.url)
 
-        self.proid, _ = self.url[len('zookeeper://'):].split('@')
         plugin = plugin_manager.load('treadmill.context', 'zookeeper')
         self._conn = plugin.connect(self.url)
         if self._listeners:

--- a/lib/python/treadmill/scheduler/masterapi.py
+++ b/lib/python/treadmill/scheduler/masterapi.py
@@ -164,6 +164,8 @@ def create_server(zkclient, server_id, parent_id, partition):
     zkutils.ensure_exists(zkclient, server_node, acl=[server_acl])
 
     data = zkutils.get(zkclient, server_node)
+    if not data:
+        data = {}
     data.update({
         'parent': parent_id,
         'partition': partition,

--- a/tests/master_test.py
+++ b/tests/master_test.py
@@ -1470,6 +1470,24 @@ class MasterTest(mockzk.MockZookeeperTestCase):
         )
 
     @mock.patch('kazoo.client.KazooClient.get', mock.Mock(
+        return_value=(None, None)))
+    @mock.patch('kazoo.client.KazooClient.set', mock.Mock())
+    @mock.patch('kazoo.client.KazooClient.create', mock.Mock())
+    @mock.patch('treadmill.zkutils.get', mock.Mock(return_value=None))
+    @mock.patch('treadmill.zkutils.put', mock.Mock(return_value=False))
+    def test_create_server(self):
+        """Tests create server API."""
+        zkclient = treadmill.zkutils.ZkClient()
+        masterapi.create_server(zkclient, 'foo', 'bucket0', '_default')
+        treadmill.zkutils.put.assert_called_with(
+            zkclient,
+            '/servers/foo',
+            {'parent': 'bucket0', 'partition': '_default'},
+            acl=mock.ANY,
+            check_content=True
+        )
+
+    @mock.patch('kazoo.client.KazooClient.get', mock.Mock(
         return_value=('{}', None)))
     @mock.patch('kazoo.client.KazooClient.set', mock.Mock())
     @mock.patch('kazoo.client.KazooClient.create', mock.Mock())


### PR DESCRIPTION
 * Fix for masterapi.create_server when server.
 * Remove obsolete context.zk.proid attribute.