### PR TITLE
Sync with 2018.06.05-1

### DIFF
--- a/entry_points.txt
+++ b/entry_points.txt
@@ -200,6 +200,7 @@ rdtscp = treadmill.traits:has_rdtscp
 
 [treadmill.sproc]
 ad = treadmill.sproc.ad
+alert_monitor = treadmill.sproc.alert_monitor
 appcfgmgr = treadmill.sproc.appcfgmgr
 appevents = treadmill.sproc.appevents
 appmonitor = treadmill.sproc.appmonitor
@@ -289,5 +290,9 @@ node-down = treadmill.monitor:MonitorNodeDown
 container-down = treadmill.monitor:MonitorContainerDown
 
 [treadmill.version_monitor]
+
+
+[treadmill.alert.plugins]
+
 
 [treadmill.logging]

--- a/lib/python/treadmill/alert/__init__.py
+++ b/lib/python/treadmill/alert/__init__.py
@@ -1,0 +1,52 @@
+"""Treadmill alert module."""
+
+import io
+import json
+import os.path
+import time
+
+from treadmill import fs
+
+
+def create(
+        alerts_dir,
+        epoch_ts=None,
+        instanceid=None,
+        summary=None,
+        type_=None,
+        **kwargs
+):
+    """Create a file in alerts_dir representing the alert."""
+    fs.write_safe(
+        os.path.join(alerts_dir, _to_filename(instanceid, type_)),
+        lambda f: f.write(
+            json.dumps(
+                dict(
+                    epoch_ts=epoch_ts or time.time(),
+                    instanceid=instanceid,
+                    summary=summary,
+                    type_=type_,
+                    **kwargs),
+                indent=4
+            ).encode()
+        ),
+        permission=0o644)
+
+
+def _to_filename(instanceid, type_):
+    """Returns a host wide unique filename for the alert.
+
+    Alerts sorted alphabetically result in chronological order.
+    """
+    return '{:f}-{}-{}'.format(time.monotonic(), instanceid, type_)
+
+
+def read(filename, alerts_dir=None):
+    """Return the alert stored in the file and delete the file."""
+    if alerts_dir is not None:
+        filename = os.path.join(alerts_dir, filename)
+
+    with io.open(filename, 'rb') as file_:
+        alert = json.loads(file_.read().decode())
+
+    return alert

--- a/lib/python/treadmill/api/instance.py
+++ b/lib/python/treadmill/api/instance.py
@@ -40,12 +40,14 @@ def _validate(rsrc):
     """Validate instance manifest."""
     memory_mb = utils.megabytes(rsrc['memory'])
     if memory_mb < 100:
-        raise exc.TreadmillError(
+        raise exc.InvalidInputError(
+            __name__,
             'memory size should be larger than or equal to 100M')
 
     disk_mb = utils.megabytes(rsrc['disk'])
     if disk_mb < 100:
-        raise exc.TreadmillError(
+        raise exc.InvalidInputError(
+            __name__,
             'disk size should be larger than or equal to 100M')
 
 

--- a/lib/python/treadmill/api/server.py
+++ b/lib/python/treadmill/api/server.py
@@ -36,10 +36,11 @@ class API(object):
             if cell:
                 filter_['cell'] = cell
 
+            result = _admin_svr().list(filter_)
             if partition:
-                filter_['partition'] = partition
-
-            return _admin_svr().list(filter_)
+                result = [x for x in result if
+                          (x['partition'] == partition)]
+            return result
 
         @schema.schema({'$ref': 'server.json#/resource_id'})
         def get(rsrc_id):

--- a/lib/python/treadmill/appcfg/manifest.py
+++ b/lib/python/treadmill/appcfg/manifest.py
@@ -349,11 +349,11 @@ def add_linux_services(manifest):
 def add_manifest_features(manifest, runtime):
     """Configure optional container features."""
     for feature in manifest.get('features', []):
-        feature_mod = features.get_feature(feature)()
-
-        if feature_mod is None:
+        if not features.feature_exists(feature):
             _LOGGER.error('Unable to load feature: %s', feature)
             raise Exception('Unsupported feature: ' + feature)
+
+        feature_mod = features.get_feature(feature)()
 
         if not feature_mod.applies(manifest, runtime):
             _LOGGER.error('Feature does not apply: %s', feature)

--- a/lib/python/treadmill/appenv/appenv.py
+++ b/lib/python/treadmill/appenv/appenv.py
@@ -29,6 +29,7 @@ class AppEnvironment(object):
     """
 
     __slots__ = (
+        'alerts_dir',
         'apps_dir',
         'app_events_dir',
         'app_types',
@@ -52,6 +53,7 @@ class AppEnvironment(object):
         'watchdog_dir',
     )
 
+    ALERTS_DIR = 'alerts'
     APPS_DIR = 'apps'
     BIN_DIR = 'bin'
     ARCHIVES_DIR = 'archives'
@@ -71,6 +73,7 @@ class AppEnvironment(object):
     def __init__(self, root):
         self.root = root
 
+        self.alerts_dir = os.path.join(self.root, self.ALERTS_DIR)
         self.apps_dir = os.path.join(self.root, self.APPS_DIR)
         self.bin_dir = os.path.join(self.root, self.BIN_DIR)
         self.watchdog_dir = os.path.join(self.root, self.WATCHDOG_DIR)

--- a/lib/python/treadmill/bootstrap/master/linux/treadmill/init/alert_monitor.yml
+++ b/lib/python/treadmill/bootstrap/master/linux/treadmill/init/alert_monitor.yml
@@ -1,10 +1,9 @@
 command: |
-  exec \
-    {{ treadmill }}/bin/treadmill \
-    sproc \
-    appmonitor \
-        --api http+unix://%2Ftmp%2Fcellapi.sock \
-        --approot /treadmill
+  CHOWN={{ _alias.chown }}
+
+  ${CHOWN} -R {{ treadmillid }} /treadmill/alerts
+
+  exec {{ python }} -m treadmill sproc alert-monitor --approot /treadmill
 environ_dir: "/treadmill/env"
 environ:
   KRB5CCNAME: "FILE:/var/spool/tickets/{{ treadmillid }}"

--- a/lib/python/treadmill/discovery.py
+++ b/lib/python/treadmill/discovery.py
@@ -18,6 +18,16 @@ from treadmill import zknamespace as z
 _LOGGER = logging.getLogger(__name__)
 
 
+def _join_prefix(prefix, arg):
+    """Return arg with the provided prefix joined."""
+    return '.'.join([prefix, arg])
+
+
+def _split_prefix(arg):
+    """Return a list containing: [prefix, arg_wo_prefix]."""
+    return arg.split('.', 1)
+
+
 class Discovery(object):
     """Treadmill endpoint discovery."""
 
@@ -25,17 +35,21 @@ class Discovery(object):
         _LOGGER.debug('Treadmill discovery: %s:%s', pattern, endpoint)
 
         self.queue = queue.Queue()
+
         # Pattern is assumed to be in the form of <proid>.<pattern>
-        self.prefix, self.pattern = pattern.split('.', 1)
-        if '#' not in self.pattern:
-            self.pattern = self.pattern + '#*'
+        patterns = [pattern] if not isinstance(pattern, list) else pattern
+        self.patterns = [
+            pattern if '#' in pattern else pattern + '#*'
+            for pattern in patterns
+        ]
+
         self.endpoint = endpoint
 
         self.state = set()
         self.zkclient = zkclient
 
     def iteritems(self, block=True, timeout=None):
-        """List matching endpoints. """
+        """List matching endpoints."""
         while True:
             try:
                 endpoint, hostport = self.queue.get(block, timeout)
@@ -62,23 +76,26 @@ class Discovery(object):
 
         match = self.get_endpoints_zk(watch_cb=watch_cb)
 
-        created = match - set(self.state)
-        deleted = set(self.state) - match
+        # let's read self.state only once as this func can be executed
+        # simultaneously (it's a Zk callback func)
+        state = set(self.state)
+        created = match - state
+        deleted = state - match
 
         for endpoint in created:
             _LOGGER.debug('added endpoint: %s', endpoint)
             hostport = self.resolve_endpoint(endpoint)
-            self.queue.put(('.'.join([self.prefix, endpoint]), hostport))
+            self.queue.put((endpoint, hostport))
 
         for endpoint in deleted:
             _LOGGER.debug('deleted endpoint: %s', endpoint)
-            self.queue.put(('.'.join([self.prefix, endpoint]), None))
+            self.queue.put((endpoint, None))
 
         self.state = match
 
     def snapshot(self):
         """Returns the current state of the matching endpoints."""
-        return ['.'.join([self.prefix, endpoint]) for endpoint in self.state]
+        return list(self.state)
 
     def exit_loop(self):
         """Put termination event on the queue."""
@@ -87,31 +104,58 @@ class Discovery(object):
     def get_endpoints(self):
         """Returns the current list of endpoints in host:port format"""
         endpoints = self.get_endpoints_zk()
-        hostports = [self.resolve_endpoint(endpoint)
-                     for endpoint in endpoints]
+        hostports = [self.resolve_endpoint(endpoint) for endpoint in endpoints]
         return hostports
 
     def get_endpoints_zk(self, watch_cb=None):
-        """Returns the current list of endpoints."""
-        endpoints_path = z.join_zookeeper_path(z.ENDPOINTS, self.prefix)
-        full_pattern = ':'.join([self.pattern, '*', self.endpoint])
-        try:
-            endpoints = self.zkclient.get_children(
-                endpoints_path, watch=watch_cb
-            )
+        """
+        Returns the current list of endpoints in the form of
+        <proid>.endpoint_filename.
+        """
+        match = set()
+        for prefix in self._prefixes():
+            endpoints_path = z.join_zookeeper_path(z.ENDPOINTS, prefix)
+            try:
+                endpoints = [
+                    _join_prefix(prefix, endpoint) for endpoint in
+                    self.zkclient.get_children(endpoints_path, watch=watch_cb)
+                ]
+            except kazoo.exceptions.NoNodeError:
+                if watch_cb:
+                    self.zkclient.exists(endpoints_path, watch=watch_cb)
+                endpoints = []
 
-            match = set([endpoint for endpoint in endpoints
-                         if fnmatch.fnmatch(endpoint, full_pattern)])
-        except kazoo.exceptions.NoNodeError:
-            if watch_cb:
-                self.zkclient.exists(endpoints_path, watch=watch_cb)
-            match = set()
+            match = match | self._matching_endpoints(endpoints)
+
+        _LOGGER.debug('pattern matching endpoints: %s', match)
+        return match
+
+    def _prefixes(self):
+        """Return the unique application proids based on self.patterns."""
+        # Pattern is assumed to be in the form of <proid>.<pattern>
+        return set([_split_prefix(pattern)[0] for pattern in self.patterns])
+
+    def _matching_endpoints(self, endpoints):
+        """Returns the list of endpoints matching one of the patterns."""
+        # Pattern is assumed to be in the form of <proid>.<pattern>
+        # Endpoint is assumed to be in the form of <proid>.endpoint_filename
+        match = set()
+        for pattern in self.patterns:
+            full_pattern = ':'.join([pattern, '*', self.endpoint])
+            match = match | set(
+                [
+                    endpoint for endpoint in endpoints
+                    if fnmatch.fnmatch(endpoint, full_pattern)
+                ]
+            )
 
         return match
 
     def resolve_endpoint(self, endpoint):
         """Resolves a endpoint to a hostport"""
-        fullpath = z.join_zookeeper_path(z.ENDPOINTS, self.prefix, endpoint)
+        # Endpoint is assumed to be in the form of <proid>.endpoint_filename
+        prefix, endpoint_fname = _split_prefix(endpoint)
+        fullpath = z.join_zookeeper_path(z.ENDPOINTS, prefix, endpoint_fname)
         try:
             hostport, _metadata = self.zkclient.get(fullpath)
             hostport = hostport.decode()

--- a/lib/python/treadmill/rest/api/cell.py
+++ b/lib/python/treadmill/rest/api/cell.py
@@ -33,6 +33,7 @@ def init(api, cors, impl):
         'cpu': fields.String(description='Total cpu capacity'),
         'disk': fields.String(description='Total disk capacity'),
         'memory': fields.String(description='Total memory capacity'),
+        'systems': fields.List(fields.Integer(description='System')),
         'down-threshold': fields.String(description='Server down threshold'),
         'reboot-schedule': fields.String(description='Reboot schedule'),
     })

--- a/lib/python/treadmill/scheduler/backend.py
+++ b/lib/python/treadmill/scheduler/backend.py
@@ -61,3 +61,7 @@ class Backend(object):
     def update(self, _path, _data, check_content=False):
         """Set data into ZK node."""
         pass
+
+    def event_object(self):
+        """Create a new event object."""
+        pass

--- a/lib/python/treadmill/scheduler/fsbackend.py
+++ b/lib/python/treadmill/scheduler/fsbackend.py
@@ -1,0 +1,189 @@
+"""Filesystem scheduler/master backend.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from collections import namedtuple
+import io
+import logging
+import os
+import threading
+
+from treadmill import dirwatch
+from treadmill import fs
+from treadmill import utils
+from treadmill import yamlwrapper as yaml
+from treadmill import zknamespace as z
+from treadmill.zksync import utils as zksync_utils
+
+from . import backend
+
+_LOGGER = logging.getLogger(__name__)
+
+# ZK nodes that can be ignored during snapshot
+_ZK_BLACKLIST = ['//finished', '//keytabs']
+
+
+def _fpath(fsroot, zkpath):
+    """Returns file path to given zk node."""
+    if zkpath == '/':
+        return os.path.join(fsroot, '_data')
+
+    path = zkpath.lstrip('/').split('/')
+    return os.path.join(
+        fsroot,
+        '/'.join(['_' + d for d in path[:-1]]),
+        path[-1]
+    )
+
+
+def _dpath(fsroot, zkpath):
+    """Returns file path to given zk node."""
+    if zkpath == '/':
+        return fsroot
+
+    path = zkpath.lstrip('/').split('/')
+    return os.path.join(
+        fsroot,
+        '/'.join(['_' + d for d in path])
+    )
+
+
+def _write_data(fpath, data, stat):
+    """Write Zookeeper data to filesystem."""
+    zksync_utils.write_data(
+        fpath, data, stat.last_modified
+    )
+
+
+def snapshot(zkclient, root, zkpath='/'):
+    """Create a snapshot of ZK state to the filesystem."""
+    if zkpath in _ZK_BLACKLIST:
+        return
+
+    _LOGGER.debug('snapshot %s', zkpath)
+
+    fpath = _fpath(root, zkpath)
+    fs.mkdir_safe(os.path.dirname(fpath))
+
+    data, stat = zkclient.get(zkpath)
+    _write_data(fpath, data, stat)
+
+    children = zkclient.get_children(zkpath)
+    for node in children:
+        zknode = z.join_zookeeper_path(zkpath, node)
+        snapshot(zkclient, root, zknode)
+
+
+class FsBackend(backend.Backend):
+    """Implements readonly Zookeeper based storage."""
+
+    def __init__(self, fsroot):
+        self.fsroot = fsroot
+        # pylint: disable=C0103
+        self.ChildrenWatch = self._childrenwatch
+
+        self._dirwatcher = dirwatch.DirWatcher()
+        self._dirwatch_dispatcher = dirwatch.DirWatcherDispatcher(
+            self._dirwatcher)
+
+        thread = threading.Thread(target=self._run_dirwatcher)
+        thread.daemon = True
+        thread.start()
+
+        super(FsBackend, self).__init__()
+
+    def _run_dirwatcher(self):
+        """Dirwatcher loop."""
+        while True:
+            if self._dirwatcher.wait_for_events():
+                self._dirwatcher.process_events()
+
+    def _childrenwatch(self, zkpath):
+        """ChildrenWatch decorator."""
+
+        def wrap(func):
+            """Decorator body."""
+
+            def _func(_path):
+                """wrapped func."""
+                func(self.list(zkpath))
+
+            dpath = _dpath(self.fsroot, zkpath)
+            fs.mkdir_safe(dpath)
+
+            self._dirwatcher.add_dir(dpath)
+            self._dirwatch_dispatcher.register(dpath, {
+                dirwatch.DirWatcherEvent.CREATED: _func,
+                dirwatch.DirWatcherEvent.DELETED: _func,
+            })
+
+            return func
+
+        return wrap
+
+    def event_object(self):
+        """Create new event object."""
+        return threading.Event()
+
+    def list(self, zkpath):
+        """Return path listing."""
+        dpath = _dpath(self.fsroot, zkpath)
+        fs.mkdir_safe(dpath)
+        try:
+            children = os.listdir(dpath)
+            return [e for e in children if not e.startswith('_')]
+        except OSError:
+            raise backend.ObjectNotFoundError()
+
+    def get(self, zkpath):
+        """Return stored object given path."""
+        data, _ = self.get_with_metadata(zkpath)
+        return data
+
+    def get_with_metadata(self, zkpath):
+        """Return stored object with metadata."""
+        fpath = _fpath(self.fsroot, zkpath)
+        try:
+            stat = os.stat(fpath)
+            meta = namedtuple('Metadata', 'ctime')(stat.st_ctime)
+            with io.open(fpath) as datafile:
+                return yaml.load(datafile.read()), meta
+        except OSError:
+            raise backend.ObjectNotFoundError()
+
+    def exists(self, zkpath):
+        """Check if object exists."""
+        fpath = _fpath(self.fsroot, zkpath)
+        return os.path.exists(fpath)
+
+    def ensure_exists(self, zkpath):
+        """Ensure storage path exists."""
+        fpath = _fpath(self.fsroot, zkpath)
+        try:
+            fs.mkdir_safe(os.path.dirname(fpath))
+            utils.touch(fpath)
+        except OSError:
+            raise backend.ObjectNotFoundError()
+
+    def delete(self, zkpath):
+        """Delete object given the path."""
+        fpath = _fpath(self.fsroot, zkpath)
+        fs.rm_safe(fpath)
+
+    def put(self, zkpath, value):
+        """Store object at a given path."""
+        fpath = _fpath(self.fsroot, zkpath)
+        try:
+            fs.mkdir_safe(os.path.dirname(fpath))
+            with io.open(fpath, 'w') as node:
+                node.write(yaml.dump(value))
+        except OSError:
+            raise backend.ObjectNotFoundError()
+
+    def update(self, zkpath, data, check_content=True):
+        """Set data into ZK node."""
+        return self.put(zkpath, data)

--- a/lib/python/treadmill/scheduler/master.py
+++ b/lib/python/treadmill/scheduler/master.py
@@ -211,7 +211,7 @@ class Master(loader.Loader):
     def watch(self, path):
         """Constructs a watch on a given path."""
 
-        @self.backend.zkclient.ChildrenWatch(path)
+        @self.backend.ChildrenWatch(path)
         @utils.exit_on_unhandled
         def _watch(children):
             """Watch children events."""
@@ -231,7 +231,7 @@ class Master(loader.Loader):
                 self.process_complete[path].wait()
             else:
                 self.process_complete[path] = \
-                    self.backend.zkclient.handler.event_object()
+                    self.backend.event_object()
 
             _LOGGER.debug('watcher finished: %s', path)
             return True

--- a/lib/python/treadmill/scheduler/zkbackend.py
+++ b/lib/python/treadmill/scheduler/zkbackend.py
@@ -23,6 +23,8 @@ class ZkReadonlyBackend(backend.Backend):
 
     def __init__(self, zkclient):
         self.zkclient = zkclient
+        # pylint: disable=C0103
+        self.ChildrenWatch = self.zkclient.ChildrenWatch
         super(ZkReadonlyBackend, self).__init__()
 
     def list(self, path):
@@ -56,6 +58,10 @@ class ZkReadonlyBackend(backend.Backend):
             return self.zkclient.exists(path)
         except kazoo.client.NoNodeError:
             raise backend.ObjectNotFoundError()
+
+    def event_object(self):
+        """Create new event object."""
+        return self.zkclient.handler.event_object()
 
 
 class ZkBackend(ZkReadonlyBackend):

--- a/lib/python/treadmill/sproc/alert_monitor.py
+++ b/lib/python/treadmill/sproc/alert_monitor.py
@@ -1,0 +1,107 @@
+"""Process alerts."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import logging
+
+import click
+
+from treadmill import alert
+from treadmill import appenv
+from treadmill import dirwatch
+from treadmill import fs
+from treadmill import utils
+
+from treadmill import plugin_manager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _NoOpBackend(object):
+    """Dummy default alert backend if no plugin can be found."""
+
+    # W0613: unused argument ...
+    # pylint: disable=W0613
+    @staticmethod
+    def send_event(
+            type_=None,
+            instanceid=None,
+            summary=None,
+            event_time=None,
+            on_success_callback=None,
+            **kwargs
+    ):
+        """Log the alert in params."""
+        _LOGGER.critical(
+            'Alert raised: %s:%s:\n %s %s', type_, instanceid, summary, kwargs
+        )
+        on_success_callback()
+
+
+def _get_on_create_handler(alert_backend):
+    """Return a func using 'alert_backend' to handle if an alert is created."""
+
+    @utils.exit_on_unhandled
+    def _on_created(alert_file):
+        """Handler for newly created alerts."""
+
+        def _delete_alert_file():
+            fs.rm_safe(alert_file)
+
+        alert_ = alert.read(alert_file)
+        alert_backend.send_event(
+            on_success_callback=_delete_alert_file, **alert_
+        )
+
+    return _on_created
+
+
+def _load_alert_backend(plugin_name):
+    backend = _NoOpBackend()
+
+    if plugin_name is None:
+        return backend
+
+    try:
+        backend = plugin_manager.load('treadmill.alert.plugins', plugin_name)
+    except KeyError:
+        _LOGGER.info(
+            '''Alert backend '%s' could not been loaded.''', plugin_name
+        )
+
+    return backend
+
+
+def init():
+    """App main."""
+
+    @click.command(name='alert_monitor')
+    @click.option(
+        '--approot',
+        type=click.Path(exists=True),
+        envvar='TREADMILL_APPROOT',
+        required=True
+    )
+    @click.option('--plugin', help='Alert backend to use', required=False)
+    def alert_monitor_cmd(approot, plugin):
+        """Publish alerts."""
+        tm_env = appenv.AppEnvironment(root=approot)
+
+        watcher = dirwatch.DirWatcher(tm_env.alerts_dir)
+        watcher.on_created = _get_on_create_handler(
+            _load_alert_backend(plugin)
+        )
+
+        # if there are alerts in alerts_dir already
+        for alert_file in os.listdir(tm_env.alerts_dir):
+            watcher.on_created(os.path.join(tm_env.alerts_dir, alert_file))
+
+        while True:
+            if watcher.wait_for_events():
+                watcher.process_events()
+
+    return alert_monitor_cmd

--- a/lib/python/treadmill/sproc/vring.py
+++ b/lib/python/treadmill/sproc/vring.py
@@ -77,16 +77,9 @@ def init():
                         sys.exit(-1)
                     vring_endpoints.add(rule_endpoint)
 
-            # TODO: discovery is limited to one rule for now.
-            if len(rules) != 1:
-                log.critical('(TODO): multiple rules are not supported.')
-                sys.exit(-1)
-            pattern = rules[0]['pattern']
-
-            app_unique_name = appcfg.manifest_unique_name(app)
-
+            patterns = [rule['pattern'] for rule in rules]
             app_discovery = discovery.Discovery(context.GLOBAL.zk.conn,
-                                                pattern, '*')
+                                                patterns, '*')
             app_discovery.sync()
 
             # Restore default signal mask disabled by python spawning new
@@ -94,6 +87,8 @@ def init():
             #
             # TODO: should this be done as part of ZK connect?
             utils.restore_signals()
+
+            app_unique_name = appcfg.manifest_unique_name(app)
 
             vring.run(
                 routing,

--- a/tests/alert/__init__.py
+++ b/tests/alert/__init__.py
@@ -1,0 +1,1 @@
+'''Unit tests for treadmill.alert.*'''

--- a/tests/alert/basic_test.py
+++ b/tests/alert/basic_test.py
@@ -1,0 +1,65 @@
+"""Unit tests for treadmill.alert.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import tempfile
+import os.path
+import unittest
+
+import mock
+from treadmill import alert
+
+
+class TestBasics(unittest.TestCase):
+    """Unit tests for treadmill.alert.
+    """
+
+    # Disable W0212: accessing protected members
+    # pylint: disable=W0212
+    @mock.patch('treadmill.alert._to_filename', return_value='test.file')
+    def test_create_read(self, _):
+        """Test alert.create() and alert.read().
+        """
+        # no epoch_ts defined
+        alert_ = dict(
+            type_='test',
+            summary='test summary',
+            instanceid='testorigin',
+            foo='bar'
+        )
+
+        with tempfile.TemporaryDirectory() as alerts_dir, \
+                mock.patch('time.time', return_value=987.654):
+            alert.create(alerts_dir, **alert_)
+            alert_file = os.path.join(
+                alerts_dir,
+                alert._to_filename(alert_['instanceid'], alert_['type_'])
+            )
+
+            self.assertTrue(os.path.exists(alert_file))
+
+            # epoch_ts was None
+            alert_['epoch_ts'] = 987.654
+            self.assertEqual(alert_, alert.read(alert_file))
+
+            # check whether epoch_ts is preserved if passed to create()
+            alert_['epoch_ts'] = 1.2
+            alert.create(alerts_dir, **alert_)
+            self.assertEqual(alert_, alert.read(alert_file))
+
+    def test_to_filename(self):
+        """test alert._to_filename().
+        """
+        with mock.patch('time.monotonic', return_value=123.456):
+            self.assertEqual(
+                alert._to_filename(instanceid='origin', type_='type'),
+                '123.456000-origin-type'
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/api/server_test.py
+++ b/tests/api/server_test.py
@@ -36,11 +36,10 @@ class ApiServerTest(unittest.TestCase):
         svr_admin.list.assert_called_with({'cell': 'some-cell'})
 
         self.svr.list(partition='xxx')
-        svr_admin.list.assert_called_with({'partition': 'xxx'})
+        svr_admin.list.assert_called_with({})
 
         self.svr.list('some-cell', 'xxx')
-        svr_admin.list.assert_called_with({'cell': 'some-cell',
-                                           'partition': 'xxx'})
+        svr_admin.list.assert_called_with({'cell': 'some-cell'})
 
     @mock.patch('treadmill.context.AdminContext.conn',
                 mock.Mock(return_value=admin.Admin(None, None)))

--- a/tests/appcfg/features_test.py
+++ b/tests/appcfg/features_test.py
@@ -1,0 +1,34 @@
+"""Unit test for treadmill.appcfg.manifest.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+from treadmill.appcfg import manifest
+
+
+class AppCfgFeaturesTest(unittest.TestCase):
+    """Tests for teadmill.appcfg.features.
+    """
+
+    def test_add_missing(self):
+        """Tests adding a not existing feature.
+        """
+        mf = {
+            'services': [],
+            'system_services': [],
+            'features': ['no_such_feature']
+        }
+
+        with self.assertRaises(Exception, msg='foo') as cm:
+            manifest.add_manifest_features(mf, 'linux')
+
+        self.assertIn('Unsupported feature', str(cm.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/appenv_test.py
+++ b/tests/appenv_test.py
@@ -62,6 +62,8 @@ class AppEnvTest(unittest.TestCase):
         # TODO: Renable iptables init in linux AppEnv initialize
         # treadmill.iptables.initialize.assert_called_with('foo')
 
+        self.assertTrue(hasattr(self.tm_env, 'alerts_dir'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cli/allocation_test.py
+++ b/tests/cli/allocation_test.py
@@ -25,12 +25,26 @@ class AllocationTest(unittest.TestCase):
         self.alloc_cli = plugin_manager.load('treadmill.cli',
                                              'allocation').init()
 
+    @mock.patch('treadmill.restclient.get')
     @mock.patch('treadmill.restclient.delete',
                 mock.Mock(return_value=mock.MagicMock()))
     @mock.patch('treadmill.context.Context.admin_api',
                 mock.Mock(return_value=['http://xxx:1234']))
-    def test_allocation_delete(self):
+    def test_allocation_delete(self, get_mock):
         """Test cli.allocation: delete"""
+        # delete a tenant
+        # subtest case 1: no subtenant and reservation
+        # initiate two returning objects from two restclient.get invocations
+        return_mock1 = mock.Mock()
+        return_mock2 = mock.Mock()
+        # this one is for get all tenants
+        return_mock1.json.return_value = [{
+            '_id': None,
+            'tenant': 'tent',
+            'systems': [1, 2, 3]}]
+        # this one is for get all reservations under 'tent'
+        return_mock2.json.return_value = []
+        get_mock.side_effect = [return_mock1, return_mock2]
         result = self.runner.invoke(self.alloc_cli,
                                     ['delete', 'tent'])
         self.assertEqual(result.exit_code, 0)
@@ -38,7 +52,60 @@ class AllocationTest(unittest.TestCase):
             ['http://xxx:1234'],
             '/tenant/tent'
         )
+        calls = [mock.call(['http://xxx:1234'], '/tenant/'),
+                 mock.call(['http://xxx:1234'], '/allocation/tent')]
+        get_mock.assert_has_calls(calls)
+        self.assertEqual(treadmill.restclient.get.call_count, 2)
 
+        # subtest case 2: has subtenant
+        get_mock.reset_mock()
+        get_mock.return_value = mock.DEFAULT
+        get_mock.side_effect = None
+        return_mock1.json.return_value = [
+            {'_id': None,
+             'tenant': 'tent',
+             'systems': [1, 2, 3]},
+            {'_id': None,
+             'tenant': 'tent:subtent',
+             'systems': [1, 2, 3]}]
+        get_mock.return_value = return_mock1
+        result = self.runner.invoke(self.alloc_cli,
+                                    ['delete', 'tent'])
+        self.assertEqual(result.exit_code, 0)
+        get_mock.assert_called_once_with(['http://xxx:1234'], '/tenant/')
+
+        # subtest case 3: tenant does not exist
+        get_mock.reset_mock()
+        get_mock.return_value = mock.DEFAULT
+        from treadmill.restclient import NotFoundError
+        get_mock.side_effect = [return_mock2, NotFoundError]
+        result = self.runner.invoke(self.alloc_cli,
+                                    ['delete', 'tent'])
+        self.assertEqual(result.exit_code, 1)
+        calls = [mock.call(['http://xxx:1234'], '/tenant/'),
+                 mock.call(['http://xxx:1234'], '/allocation/tent')]
+        get_mock.assert_has_calls(calls)
+        self.assertEqual(treadmill.restclient.get.call_count, 2)
+
+        # subtest case 4: has reservation
+        get_mock.reset_mock()
+        get_mock.return_value = mock.DEFAULT
+        return_mock1.json.return_value = [
+            {'_id': None,
+             'tenant': 'tent',
+             'systems': [1, 2, 3]}]
+        return_mock2.json.return_value = [{'_id': 'tent/dev'}]
+        get_mock.side_effect = [return_mock1, return_mock2]
+        result = self.runner.invoke(self.alloc_cli,
+                                    ['delete', 'tent'])
+        self.assertEqual(result.exit_code, 0)
+        calls = [mock.call(['http://xxx:1234'], '/tenant/'),
+                 mock.call().json(),
+                 mock.call(['http://xxx:1234'], '/allocation/tent')]
+        get_mock.assert_has_calls(calls)
+        self.assertEqual(treadmill.restclient.get.call_count, 2)
+
+        # delete all reservations
         result = self.runner.invoke(self.alloc_cli,
                                     ['delete', 'tent/dev'])
         self.assertEqual(result.exit_code, 0)
@@ -47,6 +114,7 @@ class AllocationTest(unittest.TestCase):
             '/allocation/tent/dev'
         )
 
+        # delete a reservation
         result = self.runner.invoke(self.alloc_cli,
                                     ['delete', 'tent/dev/rr'])
         self.assertEqual(result.exit_code, 0)

--- a/tests/discovery_test.py
+++ b/tests/discovery_test.py
@@ -15,8 +15,11 @@ import kazoo.client
 import mock
 
 from treadmill import discovery
+from treadmill import zknamespace as z
 
 
+# W0212(protected-access): Access to a protected member of a client class
+# pylint: disable=W0212
 class DiscoveryTest(mockzk.MockZookeeperTestCase):
     """Mock test for treadmill.appwatch."""
 
@@ -80,10 +83,104 @@ class DiscoveryTest(mockzk.MockZookeeperTestCase):
     def test_pattern(self):
         """Checks instance aware pattern construction."""
         app_discovery = discovery.Discovery(None, 'appproid.foo', 'http')
-        self.assertEqual('foo#*', app_discovery.pattern)
+        self.assertEqual(['appproid.foo#*'], app_discovery.patterns)
 
         app_discovery = discovery.Discovery(None, 'appproid.foo#1', 'http')
-        self.assertEqual('foo#1', app_discovery.pattern)
+        self.assertEqual(['appproid.foo#1'], app_discovery.patterns)
+
+    def test_snapshot(self):
+        """Checks that snapshot is just a copy of the internal state."""
+        app_discovery = discovery.Discovery(None, 'appproid.foo.*', 'http')
+        app_discovery.state.add('foo')
+        snapshot = app_discovery.snapshot()
+        self.assertFalse(snapshot == app_discovery.state)
+        self.assertEqual(set(snapshot), app_discovery.state)
+
+    def test_prefixes(self):
+        """Dummy _prefixes() test."""
+        app_discovery = discovery.Discovery(
+            None, ['appproid.foo*', 'fooproid.bar*'], '*'
+        )
+        self.assertEqual(
+            app_discovery._prefixes(), set(('appproid', 'fooproid'))
+        )
+
+    def test_matching_endpoints(self):
+        """_matching_endpoints()"""
+        app_discovery = discovery.Discovery(
+            None, ['proid_A.kafka*', 'proid_B.zookeeper*'], '*'
+        )
+        endpoints = []
+        self.assertEqual(app_discovery._matching_endpoints(endpoints), set(()))
+        endpoints = [
+            discovery._join_prefix('proid_A', endpoint) for endpoint in [
+                'kafka#111:tcp:http', 'kafka#111:tcp:kafka_cluster_comm',
+                'other#222:tcp:foo', 'asdf#333:tcp:bar',
+            ]
+        ]
+        endpoints.extend(
+            [
+                discovery._join_prefix('proid_B', endpoint) for endpoint in [
+                    'zookeeper#444:tcp:zk_listener', 'zookeeper#444:tcp:http',
+                    'xzy#555:tcp:http'
+                ]
+            ]
+        )
+        self.assertEqual(
+            app_discovery._matching_endpoints(endpoints),
+            set(
+                (
+                    'proid_A.kafka#111:tcp:http',
+                    'proid_A.kafka#111:tcp:kafka_cluster_comm',
+                    'proid_B.zookeeper#444:tcp:http',
+                    'proid_B.zookeeper#444:tcp:zk_listener',
+                )
+            )
+        )
+
+    @mock.patch(
+        'treadmill.zkutils.connect',
+        mock.Mock(return_value=kazoo.client.KazooClient())
+    )
+    def test_get_endpoints_zk(self):
+        """get_endpoints_zk(); get_endpoints()"""
+        zkclient = mock.Mock()
+        zkclient.get_children.return_value = [
+            'foo.1#0:tcp:http', 'foo.2#0:tcp:http', 'foo.1#0:tcp:tcp',
+            'bar.3#0:tcp:http'
+        ]
+
+        app_discovery = discovery.Discovery(
+            zkclient, ['proid_A.foo.1*', 'proid_B.bar.3*'], '*'
+        )
+
+        self.assertEqual(
+            app_discovery.get_endpoints_zk(),
+            set(
+                (
+                    'proid_A.foo.1#0:tcp:http', 'proid_A.foo.1#0:tcp:tcp',
+                    'proid_B.bar.3#0:tcp:http'
+                )
+            )
+        )
+
+        # Test get_endpoints()
+        def zk_get(fullpath):
+            """Mock the zkclient.get() method."""
+            if fullpath.startswith(
+                    z.join_zookeeper_path(z.ENDPOINTS, 'proid_A', 'foo')
+            ):
+                return (b'xxx:123', None)
+            if fullpath.startswith(
+                    z.join_zookeeper_path(z.ENDPOINTS, 'proid_B', 'bar')
+            ):
+                return (b'yyy:987', None)
+
+        zkclient.get = zk_get
+        self.assertEqual(
+            set(app_discovery.get_endpoints()),
+            set(('xxx:123', 'xxx:123', 'yyy:987'))
+        )
 
 
 if __name__ == '__main__':

--- a/tests/fsbackend.py
+++ b/tests/fsbackend.py
@@ -1,0 +1,40 @@
+"""Unit test for Treadmill rrdutils module.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+# Disable W0611: Unused import
+import tests.treadmill_test_skip_windows  # pylint: disable=W0611
+
+from treadmill.scheduler import fsbackend
+
+
+class FsBackendTest(unittest.TestCase):
+    """FsBackend unit tests.
+    """
+
+    # pylint: disable=protected-access
+    def test_fpath(self):
+        """Test _fpath.
+        """
+        self.assertEqual(
+            fsbackend._fpath('/root', 'a/b/c'),
+            '/root/_a/_b/c'
+        )
+
+    def test_dpath(self):
+        """Test _dpath.
+        """
+        self.assertEqual(
+            fsbackend._dpath('/root', 'a/b/c'),
+            '/root/_a/_b/_c'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sproc/alert_monitor_test.py
+++ b/tests/sproc/alert_monitor_test.py
@@ -1,0 +1,76 @@
+"""Unit tests for treadmill.sproc.alert_monitor.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import tempfile
+import unittest
+
+from treadmill import alert
+from treadmill.sproc import alert_monitor
+
+import mock
+
+
+class AlertMonitorTest(unittest.TestCase):
+    """Test treadmill.sproc.alert_monitor.
+    """
+
+    # pylint: disable=protected-access
+
+    @mock.patch('treadmill.sproc.alert_monitor._LOGGER')
+    def test_noopbackend(self, logger_mock):
+        """Test _NoOpBackend().
+        """
+        alert_ = dict(
+            type_='test',
+            summary='test summary',
+            instanceid='origin',
+            foo='bar'
+        )
+
+        with tempfile.TemporaryDirectory() as alerts_dir:
+            on_created = alert_monitor._get_on_create_handler(
+                alert_monitor._load_alert_backend(None)
+            )
+
+            alert.create(alerts_dir, **alert_)
+            alert_file = os.listdir(alerts_dir)[0]
+
+            on_created(os.path.join(alerts_dir, alert_file))
+
+            logger_mock.critical.assert_called_once_with(
+                mock.ANY, alert_['type_'], alert_['instanceid'],
+                alert_['summary'], {
+                    'foo': 'bar',
+                    'epoch_ts': mock.ANY
+                }
+            )
+
+            # check that success callback is invoked and the alert is deleted
+            with self.assertRaises(FileNotFoundError):
+                alert.read(alert_file, alerts_dir)
+
+    def test_load_alert_backend(self):
+        """Test _load_alert_backend().
+        """
+        self.assertTrue(
+            isinstance(
+                alert_monitor._load_alert_backend(None),
+                alert_monitor._NoOpBackend
+            )
+        )
+        self.assertTrue(
+            isinstance(
+                alert_monitor._load_alert_backend('No such backend'),
+                alert_monitor._NoOpBackend
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sproc/appmonitor_test.py
+++ b/tests/sproc/appmonitor_test.py
@@ -9,10 +9,10 @@ from __future__ import unicode_literals
 import time
 import unittest
 
-import mock
-
 # Disable W0611: Unused import
 import tests.treadmill_test_skip_windows  # pylint: disable=W0611
+
+import mock
 
 from treadmill import restclient
 from treadmill import zkutils
@@ -28,6 +28,7 @@ class AppMonitorTest(unittest.TestCase):
     def test_reevaluate(self):
         """Test state reevaluation."""
         zkclient = mock.Mock()
+        alerter = mock.Mock()
 
         state = {
             'scheduled': {
@@ -53,16 +54,18 @@ class AppMonitorTest(unittest.TestCase):
 
         time.time.return_value = 101
 
-        appmonitor.reevaluate('/cellapi.sock', state, zkclient, {})
+        appmonitor.reevaluate('/cellapi.sock', alerter, state, zkclient, {})
         self.assertFalse(restclient.post.called)
+        self.assertFalse(alerter.called)
 
         state['scheduled']['foo.baz'].append('foo.baz#5')
-        appmonitor.reevaluate('/cellapi.sock', state, zkclient, {})
+        appmonitor.reevaluate('/cellapi.sock', alerter, state, zkclient, {})
         restclient.post.assert_called_with(
             ['/cellapi.sock'],
             '/instance/_bulk/delete', payload={'instances': ['foo.baz#3']},
             headers={'X-Treadmill-Trusted-Agent': 'monitor'}
         )
+        self.assertFalse(alerter.called)
 
         self.assertEqual(101, state['monitors']['foo.bar']['last_update'])
         self.assertEqual(101, state['monitors']['foo.baz']['last_update'])
@@ -77,7 +80,7 @@ class AppMonitorTest(unittest.TestCase):
 
         time.time.return_value = 102
         state['scheduled']['foo.bar'] = []
-        appmonitor.reevaluate('/cellapi.sock', state, zkclient, {})
+        appmonitor.reevaluate('/cellapi.sock', alerter, state, zkclient, {})
         self.assertEqual(102, state['monitors']['foo.bar']['last_update'])
         self.assertEqual(2.0, state['monitors']['foo.bar']['available'])
 
@@ -87,7 +90,7 @@ class AppMonitorTest(unittest.TestCase):
 
         time.time.return_value = 103
         state['scheduled']['foo.bar'] = ['foo.bar#5', 'foo.bar#6']
-        appmonitor.reevaluate('/cellapi.sock', state, zkclient, {})
+        appmonitor.reevaluate('/cellapi.sock', alerter, state, zkclient, {})
         self.assertEqual(103, state['monitors']['foo.bar']['last_update'])
         self.assertEqual(3.0, state['monitors']['foo.bar']['available'])
 
@@ -96,21 +99,23 @@ class AppMonitorTest(unittest.TestCase):
 
         state['scheduled']['foo.bar'] = []
 
-        appmonitor.reevaluate('/cellapi.sock', state, zkclient, {})
+        appmonitor.reevaluate('/cellapi.sock', alerter, state, zkclient, {})
         restclient.post.assert_called_with(
             ['/cellapi.sock'],
             '/instance/foo.bar?count=2', payload={},
             headers={'X-Treadmill-Trusted-Agent': 'monitor'}
         )
+        self.assertFalse(alerter.called)
         self.assertEqual(1.0, state['monitors']['foo.bar']['available'])
 
         last_waited = appmonitor.reevaluate(
-            '/cellapi.sock', state, zkclient, {})
+            '/cellapi.sock', alerter, state, zkclient, {})
         restclient.post.assert_called_with(
             ['/cellapi.sock'],
             '/instance/foo.bar?count=1', payload={},
             headers={'X-Treadmill-Trusted-Agent': 'monitor'}
         )
+        self.assertFalse(alerter.called)
         self.assertEqual(0.0, state['monitors']['foo.bar']['available'])
         self.assertEqual(last_waited, {})
 
@@ -119,17 +124,23 @@ class AppMonitorTest(unittest.TestCase):
 
         state['scheduled']['foo.bar'] = []
         last_waited = appmonitor.reevaluate(
-            '/cellapi.sock', state, zkclient, {})
+            '/cellapi.sock', alerter, state, zkclient, {})
         self.assertFalse(restclient.post.called)
+        alerter.assert_called_with(
+            'foo.bar', 'Monitor suspended: Rate limited'
+        )
         self.assertEqual(last_waited, {'foo.bar': 104})
 
         time.time.return_value = 104
         last_waited = appmonitor.reevaluate(
-            '/cellapi.sock', state, zkclient, last_waited)
+            '/cellapi.sock', alerter, state, zkclient, last_waited)
         restclient.post.assert_called_with(
             ['/cellapi.sock'],
             '/instance/foo.bar?count=1', payload={},
             headers={'X-Treadmill-Trusted-Agent': 'monitor'}
+        )
+        alerter.assert_called_with(
+            'foo.bar', 'Monitor active again', status='clear'
         )
         self.assertEqual(0.0, state['monitors']['foo.bar']['available'])
         self.assertEqual(last_waited, {})
@@ -140,6 +151,7 @@ class AppMonitorTest(unittest.TestCase):
     def test_reevaluate_notfound(self):
         """Test state reevaluation."""
         zkclient = mock.Mock()
+        alerter = mock.Mock()
 
         state = {
             'scheduled': {
@@ -160,29 +172,39 @@ class AppMonitorTest(unittest.TestCase):
 
         restclient.post.side_effect = restclient.NotFoundError('xxx')
 
-        appmonitor.reevaluate('/cellapi.sock', state, zkclient, {})
+        appmonitor.reevaluate('/cellapi.sock', alerter, state, zkclient, {})
         self.assertTrue(restclient.post.called)
         self.assertIn('foo.bar', state['suspended'])
         self.assertEqual(state['suspended']['foo.bar'], float(101 + 300))
         zkutils.update.assert_called_with(
             zkclient, '/app-monitors', {'foo.bar': float(101 + 300)}
         )
+        alerter.assert_called_with(
+            'foo.bar', 'Monitor suspended: App not configured'
+        )
 
         restclient.post.reset_mock()
         time.time.return_value = 102
-        appmonitor.reevaluate('/cellapi.sock', state, zkclient, {})
+        appmonitor.reevaluate('/cellapi.sock', alerter, state, zkclient, {})
         self.assertFalse(restclient.post.called)
         self.assertIn('foo.bar', state['suspended'])
+        alerter.assert_called_with(
+            'foo.bar', 'Monitor suspended: App not configured'
+        )
         # Delay did not increase
         self.assertEqual(state['suspended']['foo.bar'], float(101 + 300))
 
         # After time reached, call will happen, fail, and delay will be
         # extended.
+        alerter.reset_mock()
         restclient.post.reset_mock()
         time.time.return_value = 500
         last_waited = appmonitor.reevaluate(
-            '/cellapi.sock', state, zkclient, {})
+            '/cellapi.sock', alerter, state, zkclient, {})
         self.assertTrue(restclient.post.called)
+        alerter.assert_called_with(
+            'foo.bar', 'Monitor suspended: App not configured'
+        )
         self.assertIn('foo.bar', state['suspended'])
         self.assertEqual(state['suspended']['foo.bar'], float(500 + 300))
         zkutils.update.assert_called_with(
@@ -192,14 +214,18 @@ class AppMonitorTest(unittest.TestCase):
 
         # More time pass, and this time call will succeed - application will
         # be removed from delay dict.
+        alerter.reset_mock()
         restclient.post.reset_mock()
         restclient.post.return_value = ()
         restclient.post.side_effect = None
         time.time.return_value = 500 + 300 + 1
         last_waited = appmonitor.reevaluate(
-            '/cellapi.sock', state, zkclient, last_waited)
+            '/cellapi.sock', alerter, state, zkclient, last_waited)
         self.assertTrue(restclient.post.called)
         self.assertNotIn('foo.bar', state['suspended'])
+        alerter.assert_called_with(
+            'foo.bar', 'Monitor active again', status='clear'
+        )
         zkutils.update.assert_called_with(
             zkclient, '/app-monitors', {}
         )


### PR DESCRIPTION
 * proper way to wait for dockerd ready before launching docker client
 * native: Automatically mount everything in the etc overlay.
 * send alerts on monitor suspended
 * fix `server --cell <cell> --partition '_default'` does not work
 * Added VRing support for more than one rule.
 * Fixed the error thrown when non-existant feature is added.
 * add the systems info to partitions when configure a cell.
 * Fixed a issue causing the API returns status 500 instead of 400 when
   run a app with memory (/disk) < 100M
 * Added simple service to forward alerts to an alert backend.
 * Add explict error message when deleting allocation with
   sub-resources.
 * add FsBackend to scheduler
 * Added simple alert module to drop files in an alert directory.