### PR TITLE
Sync with 2018.07.12-1

### DIFF
--- a/lib/python/treadmill/api/instance.py
+++ b/lib/python/treadmill/api/instance.py
@@ -146,6 +146,8 @@ class API(object):
             # Check scheduled quota.
             zkclient = context.GLOBAL.zk.conn
             scheduled_stats = masterapi.get_scheduled_stats(zkclient)
+            if not scheduled_stats:
+                scheduled_stats = {}
 
             total_apps = sum(scheduled_stats.values())
             if total_apps + count > _TOTAL_SCHEDULED_QUOTA:

--- a/lib/python/treadmill/appcfg/features/docker.py
+++ b/lib/python/treadmill/appcfg/features/docker.py
@@ -45,6 +45,8 @@ def _generate_dockerd_service(manifest, tm_env):
         },
         'command': (
             'exec {dockerd}'
+            ' --add-runtime docker-runc={docker_runtime}'
+            ' --default-runtime=docker-runc'
             ' --exec-opt native.cgroupdriver=cgroupfs'
             ' --bridge=none'
             ' --ip-forward=false'
@@ -56,6 +58,7 @@ def _generate_dockerd_service(manifest, tm_env):
             ' --add-registry {registry}'
         ).format(
             dockerd=subproc.resolve('dockerd'),
+            docker_runtime=subproc.resolve('docker_runtime'),
             gid=proid_gid,
             registry=_get_docker_registry(tm_env),
         ),

--- a/lib/python/treadmill/bootstrap/aliases.py
+++ b/lib/python/treadmill/bootstrap/aliases.py
@@ -48,6 +48,7 @@ _LINUX_ALIASES = {
     'dmesg': _BIN,
     'docker': _USR_BIN,
     'dockerd': _USR_BIN,
+    'docker_runtime': '/usr/libexec/docker/docker-runc-current',
     'dumpe2fs': _SBIN,
     'echo': _BIN,
     'expr': _USR_BIN,

--- a/lib/python/treadmill/bootstrap/master/linux/treadmill/data/checkout/.owner
+++ b/lib/python/treadmill/bootstrap/master/linux/treadmill/data/checkout/.owner
@@ -1,0 +1,1 @@
+{{ treadmillid }}

--- a/lib/python/treadmill/etc/ldap/schema.yml
+++ b/lib/python/treadmill/etc/ldap/schema.yml
@@ -132,9 +132,9 @@ attributeTypes:
   service-image:
     desc: Treadmill docker image
     type: str
-  service-args:
-    desc: Treadmill docker arguments
-    type: str
+  service-useshell:
+    desc: Use a shell to interpret the Treadmill command
+    type: bool
   service-name:
     desc: Treadmill service
     type: str
@@ -286,7 +286,7 @@ objectClasses:
     - service-name
     - service-command
     - service-image
-    - service-args
+    - service-useshell
     - service-root
     - service-restart-limit
     - service-restart-interval

--- a/lib/python/treadmill/sproc/tickets.py
+++ b/lib/python/treadmill/sproc/tickets.py
@@ -24,6 +24,7 @@ import click
 
 from treadmill import appenv
 from treadmill import endpoints
+from treadmill import fs
 from treadmill import tickets
 from treadmill import context
 from treadmill import zknamespace as z
@@ -60,6 +61,9 @@ def _construct_keytab(keytabs):
     kt_target = os.environ.get('KRB5_KTNAME')
     cmd_line = ['kt_add', kt_target] + temp_keytabs + file_keytabs
     subproc.check_call(cmd_line)
+
+    for temp_keytab in temp_keytabs:
+        fs.rm_safe(temp_keytab)
 
 
 def _renew_tickets(tkt_spool_dir):

--- a/lib/python/treadmill/websocket/client.py
+++ b/lib/python/treadmill/websocket/client.py
@@ -97,9 +97,16 @@ def ws_loop(wsapi, message, snapshot, on_message, on_error=None,
                 # TODO: we never use proxy when connecting to websocket
                 #       server. It is not clear if such behavior need to be
                 #       optional.
+                #
+                #       Need to set both http_proxy_host AND http_no_proxy.
+                #       The code in websocket client only examines _no_proxy if
+                #       http_proxy_host is set. If it is not, it ignores the
+                #       no_proxy setting, and latter on initializes proxy from
+                #       environment variables (BUG).
                 ws_conn = ws_client.create_connection(
                     api,
                     timeout=timeout,
+                    http_proxy_host='__ignored__.yet.must.be.set',
                     http_no_proxy=[host]
                 )
                 _LOGGER.debug('Connected.')


### PR DESCRIPTION
 * dockerd: Used an alias to identify the installed runc runtime
 * Disable proxy for websocket client.
 * Instance API crash if scheduler stats are not present.
 * Properly handle gssapi errors.
 * schema: Add a flag to enable/disable running the command with a shell.
 * Fix checkout error - Permission denied: '/treadmill/data/checkout/*.html'
 * Fix leaking temp keytabs.