### PR TITLE
Sync with 2018.09.26-1

### DIFF
--- a/lib/python/treadmill/appcfg/manifest.py
+++ b/lib/python/treadmill/appcfg/manifest.py
@@ -183,15 +183,14 @@ def add_linux_system_services(tm_env, manifest):
                     'interval': 60,
                 },
                 'command': (
+                    'unset TREADMILL_ZOOKEEPER; '
                     'exec {treadmill}/bin/treadmill sproc'
-                    ' --zookeeper {zkurl}'
                     ' --cell {cell}'
                     ' vring'
                     ' --approot {tm_root}'
                     ' {manifest}'
                 ).format(
                     treadmill=subproc.resolve('treadmill'),
-                    zkurl=manifest['zookeeper'],
                     cell=cell,
                     tm_root=tm_env.root,
                     manifest=os.path.join(container_data_dir, 'state.json')

--- a/lib/python/treadmill/cleanup.py
+++ b/lib/python/treadmill/cleanup.py
@@ -88,12 +88,15 @@ class Cleanup:
             return
 
         _LOGGER.info('Configure cleaning app: %s', name)
+
+        bin_name = 'scripts' if os.name == 'nt' else 'bin'
         command = (
-            '{treadmill}/bin/treadmill sproc cleanup instance'
+            '{treadmill}/{bin}/treadmill sproc cleanup instance'
             ' --approot {tm_root}'
             ' {instance}'
         ).format(
             treadmill=subproc.resolve('treadmill'),
+            bin=bin_name,
             tm_root=self.tm_env.root,
             instance=name
         )
@@ -109,8 +112,10 @@ class Cleanup:
             monitor_policy={
                 'limit': 5,
                 'interval': 60,
-                'tombstone': os.path.join(self.tm_env.cleanup_tombstone_dir,
-                                          name),
+                'tombstone': {
+                    'path': self.tm_env.cleanup_tombstone_dir,
+                    'id': name,
+                },
                 'skip_path': os.path.join(self.tm_env.cleanup_dir, name)
             },
             log_run_script=None,

--- a/lib/python/treadmill/cli/admin/blackout.py
+++ b/lib/python/treadmill/cli/admin/blackout.py
@@ -9,13 +9,16 @@ import re
 
 import click
 import kazoo
+import time
 
+from treadmill import cli
+from treadmill import context
 from treadmill import presence
 from treadmill import utils
-from treadmill import zkutils
-from treadmill import context
-from treadmill import cli
 from treadmill import zknamespace as z
+from treadmill import zkutils
+
+from treadmill.scheduler import masterapi
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -109,25 +112,6 @@ def _blackout_server(zkclient, server, reason):
     presence.kill_node(zkclient, server)
 
 
-def _blackout_app(zkclient, app, clear):
-    """Blackout app."""
-    # list current blacklist
-    blacklisted_node = z.path.blackedout_app(app)
-    if clear:
-        zkutils.ensure_deleted(zkclient, blacklisted_node)
-    else:
-        zkutils.ensure_exists(zkclient, blacklisted_node)
-
-
-def _list_blackedout_apps(zkclient):
-    """List blackedout apps."""
-    try:
-        for blacklisted in zkclient.get_children(z.BLACKEDOUT_APPS):
-            print(blacklisted)
-    except kazoo.client.NoNodeError:
-        pass
-
-
 def init():
     """Top level command handler."""
 
@@ -159,15 +143,31 @@ def init():
             _list_server_blackouts(context.GLOBAL.zk.conn, fmt)
 
     @blackout.command(name='app')
-    @click.option('--app', help='App name to blackout.')
+    @click.option('--app', help='App name/pattern to blackout.')
+    @click.option('--reason', help='Blackout reason.')
     @click.option('--clear', is_flag=True, default=False,
                   help='Clear blackout.')
-    def app_cmd(app, clear):
+    def app_cmd(app, reason, clear):
         """Manage app blackouts."""
-        if app:
-            _blackout_app(context.GLOBAL.zk.conn, app, clear)
+        zkclient = context.GLOBAL.zk.conn
 
-        _list_blackedout_apps(context.GLOBAL.zk.conn)
+        blacklist = zkutils.get_default(zkclient, z.BLACKEDOUT_APPS)
+        if not blacklist:
+            blacklist = {}
+
+        if app:
+            if clear:
+                blacklist.pop(app, None)
+            else:
+                if not reason:
+                    raise click.UsageError('--reason is required.')
+                blacklist[app] = {'reason': reason, 'when': time.time()}
+            zkutils.put(zkclient, z.BLACKEDOUT_APPS, data=blacklist)
+            masterapi.create_event(zkclient, 0, 'apps_blacklist', None)
+
+        for blacklisted, details in sorted(blacklist.items()):
+            when = utils.strftime_utc(details['when'])
+            cli.out('[%s] %s %s', when, blacklisted, details['reason'])
 
     del server_cmd
     del app_cmd

--- a/lib/python/treadmill/runtime/docker/runtime.py
+++ b/lib/python/treadmill/runtime/docker/runtime.py
@@ -100,6 +100,19 @@ def _get_gmsa(tm_env, client, app, container_args):
     container_args['hostname'] = app.proid
 
 
+def _log_port_mapping_config(ports):
+    if ports:
+        port_str = ' '.join(
+            ['{}:{}'.format(c_port, h_port)
+             for c_port, h_port in ports.items()]
+        )
+    else:
+        port_str = 'none'
+
+    _LOGGER.info(
+        'port mapping config (container port/proto : host port): %s', port_str)
+
+
 def _create_container(tm_env, conf, client, app):
     """Create docker container from given app.
     """
@@ -107,6 +120,8 @@ def _create_container(tm_env, conf, client, app):
     for endpoint in app.endpoints:
         port_key = '{0}/{1}'.format(endpoint.port, endpoint.proto)
         ports[port_key] = endpoint.real_port
+
+    _log_port_mapping_config(ports)
 
     # app.image contains a uri which starts with docker://
     image_name = app.image[9:]

--- a/lib/python/treadmill/sproc/alert_monitor.py
+++ b/lib/python/treadmill/sproc/alert_monitor.py
@@ -1,13 +1,15 @@
-"""Process alerts."""
+"""Process alerts.
+"""
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import errno
+import logging
 import os
 import os.path
-import logging
 
 import click
 
@@ -20,44 +22,55 @@ from treadmill import plugin_manager
 
 _LOGGER = logging.getLogger(__name__)
 
+_DEF_WAITING_PERIOD = 120
+_DEF_MAX_QUEUE_LEN = 100
+
 
 class _NoOpBackend:
-    """Dummy default alert backend if no plugin can be found."""
-
-    # W0613: unused argument ...
-    # pylint: disable=W0613
+    """Dummy default alert backend if no plugin can be found.
+    """
     @staticmethod
-    def send_event(
-            type_=None,
-            instanceid=None,
-            summary=None,
-            event_time=None,
-            on_success_callback=None,
-            **kwargs
-    ):
-        """Log the alert in params."""
+    def send_event(type_=None,
+                   instanceid=None,
+                   summary=None,
+                   event_time=None,
+                   on_success_callback=None,
+                   **kwargs):
+        """Log the alert in params.
+        """
+        # pylint: disable=unused-argument
+
         _LOGGER.critical(
             'Alert raised: %s:%s:\n %s %s', type_, instanceid, summary, kwargs
         )
-        on_success_callback()
+        if on_success_callback is not None:
+            on_success_callback()
 
 
 def _get_on_create_handler(alert_backend):
-    """Return a func using 'alert_backend' to handle if an alert is created."""
+    """Return a func using 'alert_backend' to handle if an alert is created.
+    """
 
     def _on_created(alert_file):
-        """Handler for newly created alerts."""
+        """Handler for newly created alerts.
+        """
 
         # Avoid triggerring on temporary files
         if os.path.basename(alert_file)[0] == '.':
             return None
 
-        def _delete_alert_file():
-            fs.rm_safe(alert_file)
+        try:
+            alert_ = alert.read(alert_file)
+        except OSError as err:
+            if err.errno == errno.ENOENT:
+                # File already gone, nothing to do.
+                return None
+            else:
+                raise
 
-        alert_ = alert.read(alert_file)
         return alert_backend.send_event(
-            on_success_callback=_delete_alert_file, **alert_
+            on_success_callback=lambda: fs.rm_safe(alert_file),
+            **alert_
         )
 
     return _on_created
@@ -72,22 +85,40 @@ def _load_alert_backend(plugin_name):
     try:
         backend = plugin_manager.load('treadmill.alert.plugins', plugin_name)
     except KeyError:
-        _LOGGER.info(
-            '''Alert backend '%s' could not been loaded.''', plugin_name
-        )
+        _LOGGER.info('Alert backend %r could not been loaded.', plugin_name)
 
     return backend
 
 
-def _serve_forever(watcher):
-    """Wait for and handle events until the end of time."""
+def _serve_forever(watcher, alerts_dir, max_queue_length, wait_interval):
+    """Wait for and handle events until the end of time.
+    """
     while True:
-        if watcher.wait_for_events():
+        _process_existing_alerts(alerts_dir, watcher.on_created)
+
+        if watcher.wait_for_events(timeout=wait_interval):
             watcher.process_events()
+
+        _remove_extra_alerts(alerts_dir, max_queue_length)
+
+
+def _process_existing_alerts(alerts_dir, process_func):
+    """Retry sending the alerts in alerts_dir.
+    """
+    for alert_file in os.listdir(alerts_dir):
+        process_func(os.path.join(alerts_dir, alert_file))
+
+
+def _remove_extra_alerts(alerts_dir, max_queue_length):
+    """Keep the most recent max_queue_length files in alerts_dir.
+    """
+    for alert_file in sorted(os.listdir(alerts_dir))[:-1 * max_queue_length]:
+        fs.rm_safe(os.path.join(alerts_dir, alert_file))
 
 
 def init():
-    """App main."""
+    """App main.
+    """
 
     @click.command(name='alert_monitor')
     @click.option(
@@ -97,18 +128,31 @@ def init():
         required=True
     )
     @click.option('--plugin', help='Alert backend to use', required=False)
-    def alert_monitor_cmd(approot, plugin):
-        """Publish alerts."""
+    @click.option(
+        '--max-queue-length',
+        help='Keep at most that many files in alerts directory'
+        ', default: {}'.format(_DEF_MAX_QUEUE_LEN),
+        type=int,
+        default=_DEF_MAX_QUEUE_LEN
+    )
+    @click.option(
+        '--wait-interval',
+        help='Time to wait between WT alerting retry attempts (sec)'
+        ', default: {}'.format(_DEF_WAITING_PERIOD),
+        type=int,
+        default=_DEF_WAITING_PERIOD
+    )
+    def alert_monitor_cmd(approot, plugin, max_queue_length, wait_interval):
+        """Publish alerts.
+        """
         tm_env = appenv.AppEnvironment(root=approot)
         watcher = dirwatch.DirWatcher(tm_env.alerts_dir)
         watcher.on_created = _get_on_create_handler(
             _load_alert_backend(plugin)
         )
 
-        # if there are alerts in alerts_dir already
-        for alert_file in os.listdir(tm_env.alerts_dir):
-            watcher.on_created(os.path.join(tm_env.alerts_dir, alert_file))
-
-        _serve_forever(watcher)
+        _serve_forever(
+            watcher, tm_env.alerts_dir, max_queue_length, wait_interval
+        )
 
     return alert_monitor_cmd

--- a/lib/python/treadmill/tests/cleanup_test.py
+++ b/lib/python/treadmill/tests/cleanup_test.py
@@ -30,7 +30,9 @@ class CleanupTest(unittest.TestCase):
         self.cleanup_dir = os.path.join(self.root, 'cleanup')
         self.cleaning_dir = os.path.join(self.root, 'cleaning')
         self.cleanup_apps_dir = os.path.join(self.root, 'cleanup_apps')
-        self.cleanup_tombstone_dir = os.path.join(self.root, 'tombstones')
+        self.cleanup_tombstone_dir = os.path.join(
+            self.root, 'tombstones', 'cleanup'
+        )
 
         for tmp_dir in [self.cleanup_dir, self.cleaning_dir,
                         self.cleanup_apps_dir]:
@@ -89,8 +91,10 @@ class CleanupTest(unittest.TestCase):
             monitor_policy={
                 'limit': 5,
                 'interval': 60,
-                'tombstone': os.path.join(self.cleanup_tombstone_dir,
-                                          'proid.app#0000000000001'),
+                'tombstone': {
+                    'path': self.cleanup_tombstone_dir,
+                    'id': 'proid.app#0000000000001',
+                },
                 'skip_path': os.path.join(self.cleanup_dir,
                                           'proid.app#0000000000001')
             },

--- a/lib/python/treadmill/tests/cli/admin/blackout_test.py
+++ b/lib/python/treadmill/tests/cli/admin/blackout_test.py
@@ -1,0 +1,160 @@
+"""Unit test for treadmill.cli.blackout.logs."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+import click.testing
+import mock
+
+from treadmill import context
+from treadmill import plugin_manager
+from treadmill import zkutils
+
+from treadmill.scheduler import masterapi
+
+
+class AdminBlackoutTest(unittest.TestCase):
+    """Mock test for treadmill.cli.admin.blackout"""
+
+    def setUp(self):
+        """Setup common test variables"""
+        self.runner = click.testing.CliRunner()
+        self.blackout_mod = plugin_manager.load(
+            'treadmill.cli.admin', 'blackout'
+        )
+        self.blackout_cli = self.blackout_mod.init()
+        context.GLOBAL.cell = 'test'
+        context.GLOBAL.zk.url = 'zookeeper://xxx@yyy:123'
+        context.GLOBAL.zk = mock.Mock()
+
+    def test_list_app_blackouts(self):
+        """Test listing app blackouts."""
+        context.GLOBAL.zk.conn.get.return_value = (
+            """
+                foo.*: {reason: test, when: 1234567890.0}
+                bar.baz: {reason: test, when: 1234567890.0}
+            """,
+            mock.Mock()
+        )
+
+        res = self.runner.invoke(
+            self.blackout_cli,
+            ['--cell', 'test', 'app']
+        )
+
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(
+            res.output,
+            '[Fri, 13 Feb 2009 23:31:30+0000] bar.baz test\n'
+            '[Fri, 13 Feb 2009 23:31:30+0000] foo.* test\n'
+        )
+
+        context.GLOBAL.zk.conn.get.return_value = (None, mock.Mock())
+
+        res = self.runner.invoke(
+            self.blackout_cli,
+            ['--cell', 'test', 'app']
+        )
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(res.output, '')
+
+    @mock.patch('time.time', mock.Mock(return_value=1234567890.0))
+    @mock.patch('treadmill.zkutils.put', mock.Mock())
+    @mock.patch('treadmill.scheduler.masterapi.create_event', mock.Mock())
+    def test_blackout_app(self):
+        """Test app blackout."""
+        context.GLOBAL.zk.conn.get.return_value = (
+            """
+                foo.*: {reason: test, when: 1234567890.0}
+            """,
+            mock.Mock()
+        )
+
+        res = self.runner.invoke(
+            self.blackout_cli,
+            ['--cell', 'test', 'app', '--app', 'bar.baz', '--reason', 'test']
+        )
+
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(
+            res.output,
+            '[Fri, 13 Feb 2009 23:31:30+0000] bar.baz test\n'
+            '[Fri, 13 Feb 2009 23:31:30+0000] foo.* test\n'
+        )
+
+        zkutils.put.assert_called_once_with(
+            mock.ANY,
+            '/blackedout.apps',
+            data={
+                'foo.*': {'when': 1234567890.0, 'reason': 'test'},
+                'bar.baz': {'when': 1234567890.0, 'reason': 'test'}
+            }
+        )
+        masterapi.create_event.assert_called_once_with(
+            mock.ANY, 0, 'apps_blacklist', None
+        )
+
+        zkutils.put.reset_mock()
+        masterapi.create_event.reset_mock()
+
+        context.GLOBAL.zk.conn.get.return_value = (None, mock.Mock())
+
+        res = self.runner.invoke(
+            self.blackout_cli,
+            ['--cell', 'test', 'app', '--app', 'foo.*', '--reason', 'test']
+        )
+
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(
+            res.output,
+            '[Fri, 13 Feb 2009 23:31:30+0000] foo.* test\n'
+        )
+
+        zkutils.put.assert_called_once_with(
+            mock.ANY,
+            '/blackedout.apps',
+            data={'foo.*': {'when': 1234567890.0, 'reason': 'test'}}
+        )
+        masterapi.create_event.assert_called_once_with(
+            mock.ANY, 0, 'apps_blacklist', None
+        )
+
+    @mock.patch('time.time', mock.Mock(return_value=1234567890.0))
+    @mock.patch('treadmill.zkutils.put', mock.Mock())
+    @mock.patch('treadmill.scheduler.masterapi.create_event', mock.Mock())
+    def test_clear_app_blackout(self):
+        """Test clearing app blackout."""
+        context.GLOBAL.zk.conn.get.return_value = (
+            """
+                foo.*: {reason: test, when: 1234567890.0}
+                bar.baz: {reason: test, when: 1234567890.0}
+            """,
+            mock.Mock()
+        )
+
+        res = self.runner.invoke(
+            self.blackout_cli,
+            ['--cell', 'test', 'app', '--app', 'bar.baz', '--clear']
+        )
+
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(
+            res.output,
+            '[Fri, 13 Feb 2009 23:31:30+0000] foo.* test\n'
+        )
+
+        zkutils.put.assert_called_once_with(
+            mock.ANY,
+            '/blackedout.apps',
+            data={'foo.*': {'when': 1234567890.0, 'reason': 'test'}}
+        )
+        masterapi.create_event.assert_called_once_with(
+            mock.ANY, 0, 'apps_blacklist', None
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/python/treadmill/tests/restclient_test.py
+++ b/lib/python/treadmill/tests/restclient_test.py
@@ -102,10 +102,12 @@ class RESTClientTest(unittest.TestCase):
 
     @mock.patch('time.sleep', mock.Mock())
     @mock.patch('treadmill.restclient._handle_error', mock.Mock())
-    @mock.patch('requests.get', mock.Mock())
-    def test_retry(self):
+    @mock.patch('requests.get',
+                return_value=mock.MagicMock(requests.Response))
+    def test_retry(self, resp_mock):
         """Tests retry logic."""
 
+        resp_mock.return_value.status_code = http_client.INTERNAL_SERVER_ERROR
         with self.assertRaises(restclient.MaxRequestRetriesError) as cm:
             restclient.get(
                 ['http://foo.com', 'http://bar.com'],
@@ -121,22 +123,22 @@ class RESTClientTest(unittest.TestCase):
         requests.get.assert_has_calls([
             mock.call('http://foo.com/baz', json=None, proxies=None,
                       headers=None, auth=mock.ANY, timeout=(.5, 10),
-                      stream=None, verify=True),
+                      stream=None, verify=True, allow_redirects=True),
             mock.call('http://bar.com/baz', json=None, proxies=None,
                       headers=None, auth=mock.ANY, timeout=(.5, 10),
-                      stream=None, verify=True),
+                      stream=None, verify=True, allow_redirects=True),
             mock.call('http://foo.com/baz', json=None, proxies=None,
                       headers=None, auth=mock.ANY, timeout=(1.5, 10),
-                      stream=None, verify=True),
+                      stream=None, verify=True, allow_redirects=True),
             mock.call('http://bar.com/baz', json=None, proxies=None,
                       headers=None, auth=mock.ANY, timeout=(1.5, 10),
-                      stream=None, verify=True),
+                      stream=None, verify=True, allow_redirects=True),
             mock.call('http://foo.com/baz', json=None, proxies=None,
                       headers=None, auth=mock.ANY, timeout=(2.5, 10),
-                      stream=None, verify=True),
+                      stream=None, verify=True, allow_redirects=True),
             mock.call('http://bar.com/baz', json=None, proxies=None,
                       headers=None, auth=mock.ANY, timeout=(2.5, 10),
-                      stream=None, verify=True),
+                      stream=None, verify=True, allow_redirects=True),
         ], any_order=True)
         self.assertEqual(requests.get.call_count, 6)
 
@@ -178,7 +180,8 @@ class RESTClientTest(unittest.TestCase):
         restclient.get('http://foo.com', '/')
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY, verify=True,
-            headers=None, json=None, timeout=(0.5, 10), proxies=None
+            headers=None, json=None, timeout=(0.5, 10), proxies=None,
+            allow_redirects=True,
         )
 
     @mock.patch('requests.delete',
@@ -190,7 +193,8 @@ class RESTClientTest(unittest.TestCase):
         restclient.delete('http://foo.com', '/')
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY, verify=True,
-            headers=None, json=None, timeout=(0.5, None), proxies=None
+            headers=None, json=None, timeout=(0.5, None), proxies=None,
+            allow_redirects=True
         )
 
     @mock.patch('requests.post',
@@ -202,7 +206,8 @@ class RESTClientTest(unittest.TestCase):
         restclient.post('http://foo.com', '/', '')
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY, verify=True,
-            headers=None, json='', timeout=(0.5, None), proxies=None
+            headers=None, json='', timeout=(0.5, None), proxies=None,
+            allow_redirects=True
         )
 
     @mock.patch('requests.put', return_value=mock.MagicMock(requests.Response))
@@ -213,7 +218,8 @@ class RESTClientTest(unittest.TestCase):
         restclient.put('http://foo.com', '/', '')
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY, verify=True,
-            headers=None, json='', timeout=(0.5, None), proxies=None
+            headers=None, json='', timeout=(0.5, None), proxies=None,
+            allow_redirects=True
         )
 
     @mock.patch('requests.get', return_value=mock.MagicMock(requests.Response))
@@ -225,7 +231,7 @@ class RESTClientTest(unittest.TestCase):
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY,
             headers=None, json=None, timeout=(0.5, 10), proxies=None,
-            verify='/path/to/ca/certs'
+            verify='/path/to/ca/certs', allow_redirects=True
         )
 
     @mock.patch('requests.delete',
@@ -238,7 +244,7 @@ class RESTClientTest(unittest.TestCase):
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY,
             headers=None, json=None, timeout=(0.5, None), proxies=None,
-            verify='/path/to/ca/certs'
+            verify='/path/to/ca/certs', allow_redirects=True
         )
 
     @mock.patch('requests.post',
@@ -251,7 +257,7 @@ class RESTClientTest(unittest.TestCase):
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY,
             headers=None, json='', timeout=(0.5, None), proxies=None,
-            verify='/path/to/ca/certs'
+            verify='/path/to/ca/certs', allow_redirects=True
         )
 
     @mock.patch('requests.put', return_value=mock.MagicMock(requests.Response))
@@ -263,7 +269,7 @@ class RESTClientTest(unittest.TestCase):
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY,
             headers=None, json='', timeout=(0.5, None), proxies=None,
-            verify='/path/to/ca/certs'
+            verify='/path/to/ca/certs', allow_redirects=True
         )
 
     @mock.patch('requests.delete',
@@ -277,7 +283,7 @@ class RESTClientTest(unittest.TestCase):
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY,
             headers=None, timeout=(0.5, None), proxies=None,
-            data='payload', verify=True
+            data='payload', verify=True, allow_redirects=True
         )
 
     @mock.patch('requests.post',
@@ -291,7 +297,7 @@ class RESTClientTest(unittest.TestCase):
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY,
             headers=None, timeout=(0.5, None), proxies=None,
-            data='payload', verify=True
+            data='payload', verify=True, allow_redirects=True
         )
 
     @mock.patch('requests.put', return_value=mock.MagicMock(requests.Response))
@@ -304,7 +310,7 @@ class RESTClientTest(unittest.TestCase):
         resp_mock.assert_called_with(
             'http://foo.com/', stream=None, auth=mock.ANY,
             headers=None, timeout=(0.5, None), proxies=None,
-            data='payload', verify=True
+            data='payload', verify=True, allow_redirects=True
         )
 
 


### PR DESCRIPTION
 * Allow redirects in restapi.
 * App blackout support.
 * Fix vring service configuration to support multiple cells.
 * Fix tombstone parameter for cleanup.
 * Log port mapping setting when creating container.
 * fix treadmill path of run script of cleanup app.
 * State API - watch /scheduled nodes, show new instances faster.