### PR TITLE
Handle migration of system tasks to system cgroup.

### DIFF
--- a/lib/python/treadmill/bootstrap/aliases.py
+++ b/lib/python/treadmill/bootstrap/aliases.py
@@ -96,6 +96,7 @@ _LINUX_ALIASES = {
     'tail': _USR_BIN,
     'tar': _BIN,
     'touch': _BIN,
+    'true': _BIN,
     'tune2fs': _SBIN,
     'umount': _BIN,
     'unshare': _USR_BIN,

--- a/lib/python/treadmill/bootstrap/node/linux/bin/parts/10_cgroups.sh
+++ b/lib/python/treadmill/bootstrap/node/linux/bin/parts/10_cgroups.sh
@@ -18,6 +18,7 @@ MKTEMP="{{ _alias.mktemp }}"
 MOUNT="{{ _alias.mount }}"
 RMDIR="{{ _alias.rmdir }}"
 SLEEP="{{ _alias.sleep }}"
+TRUE="{{ _alias.true }}"
 
 set -e
 
@@ -86,12 +87,12 @@ function init_cgroup_rhel7() {
         fi
 
         for P in $(${CAT} ${CGROUP}/tasks); do
-            # Skipt kernel processes.
+            # Skip kernel processes.
             if [ -z "$(${CAT} /proc/${P}/cmdline)" ]; then
                 continue
             fi
             ${ECHO} "Moving ${P} to ${CGROUP}/system.slice"
-            ${ECHO} ${P} >${CGROUP}/system.slice/tasks
+            ${ECHO} ${P} >${CGROUP}/system.slice/tasks || ${TRUE}
         done
     done
 
@@ -259,12 +260,12 @@ function init_cgroup_rhel6() {
         fi
 
         for P in $(${CAT} ${CGROUP}/tasks); do
-            # Skipt kernel processes.
+            # Skip kernel processes.
             if [ -z "$(${CAT} /proc/${P}/cmdline)" ]; then
                 continue
             fi
             ${ECHO} "Moving ${P} to ${CGROUP}/system.slice"
-            ${ECHO} ${P} >${CGROUP}/system.slice/tasks
+            ${ECHO} ${P} >${CGROUP}/system.slice/tasks || ${TRUE}
         done
     done
 


### PR DESCRIPTION
- If task finishes while we try to migrate it to system cgroup slice,
  ignore the error.