### PR TITLE
Use global scope for admin api as default.

### DIFF
--- a/lib/python/treadmill/dnsctx.py
+++ b/lib/python/treadmill/dnsctx.py
@@ -88,17 +88,20 @@ def _admin_api(ctx, scope=None):
     # Default.
     #
     def _lookup(ctx, scope):
-        return _api(
-            ctx,
-            '_http._tcp.adminapi.{scope}'.format(scope=scope),
-            'http'
-        )
+        if scope:
+            srv = '_http._tcp.adminapi.{scope}'.format(scope=scope)
+        else:
+            srv = '_http._tcp.adminapi'
+
+        return _api(ctx, srv, 'http')
 
     if scope is not None:
         return _lookup(ctx, scope)
-
     else:
-        for api_scope in ctx.get('api_scope', []):
+        api_scopes = ctx.get('api_scope', [])
+        # Append global scope for admin api by default.
+        api_scopes.append(None)
+        for api_scope in api_scopes:
             try:
                 result = _lookup(ctx, api_scope)
                 if result:


### PR DESCRIPTION
- When resolving admin api from DNS, support global scope.