### PR TITLE
Revert "Add exception for localhost registries"

### DIFF
--- a/lib/python/treadmill/appcfg/features/docker.py
+++ b/lib/python/treadmill/appcfg/features/docker.py
@@ -137,6 +137,5 @@ def _get_docker_registry(tm_env):
             port = '5000'
 
         # Ensure we have teh FQDN for the registry host.
-        if host not in {'127.0.0.1', '192.168.254.254'}:
-            host = socket.getfqdn(host)
+        host = socket.getfqdn(host)
         yield ':'.join([host, port])


### PR DESCRIPTION
This reverts commit 01c0a49dc86600a15d8f84f6a23dfa4f251ecad7.
The issue this remedied was due to a quirk of the environment that has been fixed elsewhere. 