### PR TITLE
Sync with 2019.01.10-1

### DIFF
--- a/entry_points.txt
+++ b/entry_points.txt
@@ -30,6 +30,8 @@ warpgate = treadmill.appcfg.features.warpgate:WarpgateFeature
 
 [treadmill.apphooks]
 
+[treadmill.rest]
+limit = treadmill.rest.limit
 
 [treadmill.rest.authentication]
 trusted = treadmill.rest.auth.trusted

--- a/lib/python/treadmill/appcfg/features/docker.py
+++ b/lib/python/treadmill/appcfg/features/docker.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import logging
 import socket
 
+from treadmill import dockerutils
 from treadmill import nodedata
 from treadmill import subproc
 from treadmill.appcfg.features import feature_base
@@ -72,6 +73,8 @@ def _generate_docker_authz_service():
 def _generate_dockerd_service(tm_env):
     """Configure docker daemon services."""
     # add dockerd service
+    ulimits = dockerutils.init_ulimit()
+    default_ulimit = dockerutils.fmt_ulimit_to_flag(ulimits)
 
     # we disable advanced network features
     command = (
@@ -88,9 +91,11 @@ def _generate_dockerd_service(tm_env):
         ' --iptables=false'
         ' --cgroup-parent=docker'
         ' --block-registry="*"'
+        ' {default_ulimit}'
     ).format(
         dockerd=subproc.resolve('dockerd'),
         docker_runtime=subproc.resolve('docker_runtime'),
+        default_ulimit=default_ulimit,
     )
 
     # we only allow pull image from specified registry

--- a/lib/python/treadmill/bootstrap/node/linux/init/nodeinfo.yml
+++ b/lib/python/treadmill/bootstrap/node/linux/init/nodeinfo.yml
@@ -8,6 +8,7 @@ command: |
         --register \
         --cors-origin='.*' \
         -m local,cgroup \
+        --rate-limit '5/second' \
         --config cgroup /tmp/cgroup.cfg.yml
 environ_dir: "{{ dir }}/env"
 environ:

--- a/lib/python/treadmill/cli/allocation.py
+++ b/lib/python/treadmill/cli/allocation.py
@@ -296,13 +296,9 @@ def init():
             data = {}
             if priority:
                 data['priority'] = priority
-            existing = restclient.get(restapi, url).json()
-            rest_func = restclient.post
-            for assignment in existing:
-                if assignment['pattern'] == pattern:
-                    rest_func = restclient.put
-                    break
-            rest_func(restapi, url, payload=data)
+            # assign is always put
+            # because assign and reserve belong to the same ldap obj
+            restclient.put(restapi, url, payload=data)
 
             _display_tenant(restapi, allocation)
 

--- a/lib/python/treadmill/cli/configure.py
+++ b/lib/python/treadmill/cli/configure.py
@@ -6,7 +6,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import io
 import logging
 
 import click
@@ -37,8 +36,8 @@ def _configure(apis, manifest, appname):
             existing = None
 
     if manifest:
-        with io.open(manifest, 'rb') as fd:
-            app = yaml.load(stream=fd)
+        app = yaml.load(stream=manifest)
+
         if existing:
             response = restclient.put(
                 apis, _APP_REST_PATH + appname, payload=app
@@ -78,7 +77,7 @@ def init():
                   help='API service principal for SPNEGO auth (default HTTP)',
                   expose_value=False)
     @click.option('-m', '--manifest', help='App manifest file (stream)',
-                  type=click.Path(exists=True, readable=True))
+                  type=click.File('rb'))
     @click.option('--match', help='Application name pattern match')
     @click.option('--delete', help='Delete the app.',
                   is_flag=True, default=False)

--- a/lib/python/treadmill/cli/run.py
+++ b/lib/python/treadmill/cli/run.py
@@ -6,7 +6,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import io
 import logging
 import os
 import shlex
@@ -48,8 +47,7 @@ def _run(apis,
     # pylint: disable=R0912
     app = {}
     if manifest:
-        with io.open(manifest, 'rb') as fd:
-            app = yaml.load(stream=fd)
+        app = yaml.load(stream=manifest)
 
     if endpoint:
         app['endpoints'] = [{'name': name, 'port': port}
@@ -133,7 +131,7 @@ def init():
     @click.option('--count', help='Number of instances to start',
                   default=1)
     @click.option('-m', '--manifest', help='App manifest file (stream)',
-                  type=click.Path(exists=True, readable=True))
+                  type=click.File('rb'))
     @click.option('--memory', help='Memory demand, default %s.' % _DEFAULT_MEM,
                   metavar='G|M',
                   callback=cli.validate_memory)

--- a/lib/python/treadmill/cli/show.py
+++ b/lib/python/treadmill/cli/show.py
@@ -173,16 +173,10 @@ def init():
     @cli.handle_exceptions(restclient.CLI_REST_EXCEPTIONS)
     @click.option('--match', help='Application name pattern match')
     @click.option('--partition', help='Filter apps by partition')
-    @click.option('--details', is_flag=True, default=False,
-                  help='Show details.')
-    def finished(match, partition, details):
+    def finished(match, partition):
         """Show finished instances."""
         apis = context.GLOBAL.state_api()
-        if details:
-            return _show_finished(apis, match, partition)
-        return _show_list(
-            apis, match, _FINISHED_STATES, finished=True, partition=partition
-        )
+        return _show_finished(apis, match, partition)
 
     @show.command()
     @cli.handle_exceptions(restclient.CLI_REST_EXCEPTIONS)

--- a/lib/python/treadmill/dockerutils.py
+++ b/lib/python/treadmill/dockerutils.py
@@ -1,0 +1,48 @@
+"""Docker helper functions.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from treadmill import utils
+
+_DEFAULT_ULIMIT = ['core', 'data', 'fsize', 'nproc', 'nofile', 'rss', 'stack']
+
+
+def init_ulimit(ulimit=None):
+    """Initialize dockerd ulimits to parent process ulimit defaults.
+       Accepts an optional list of overrides.
+    """
+    total_result = []
+
+    for u_type in _DEFAULT_ULIMIT:
+        (soft_limit, hard_limit) = utils.get_ulimit(u_type)
+        total_result.append(
+            {'Name': u_type, 'Soft': soft_limit, 'Hard': hard_limit}
+        )
+
+    if ulimit:
+        for u_string in ulimit:
+            (u_type, soft_limit, hard_limit) = u_string.split(':', 3)
+            for limit in total_result:
+                if limit['Name'] == u_type:
+                    limit['Soft'] = int(soft_limit)
+                    limit['Hard'] = int(hard_limit)
+
+    return total_result
+
+
+def fmt_ulimit_to_flag(ulimits):
+    """Format rich dictionary to dockerd-compatible cli flags.
+
+       Do not respect "soft" limit as dockerd has a known issue when comparing
+       finite vs infinite values; will error on {Soft=0, Hard=-1}
+    """
+    total_result = []
+    for flag in ulimits:
+        total_result.append('--default-ulimit {}={}:{}'.format(flag['Name'],
+                                                               flag['Hard'],
+                                                               flag['Hard']))
+    return ' '.join(total_result)

--- a/lib/python/treadmill/etc/schema/assignment.json
+++ b/lib/python/treadmill/etc/schema/assignment.json
@@ -18,7 +18,6 @@
         "create": {
         },
         "update": {
-            "required": ["priority"]
         }
     }
 }

--- a/lib/python/treadmill/rest/api/instance.py
+++ b/lib/python/treadmill/rest/api/instance.py
@@ -101,6 +101,8 @@ def init(api, cors, impl):
             """Bulk deletes list of instances."""
             user = flask.g.get('user')
             instance_ids = flask.request.json['instances']
+            if not instance_ids:
+                return
             # Bulk operations are allowed on on same proid.
             proid = None
             for instance_id in instance_ids:

--- a/lib/python/treadmill/rest/limit.py
+++ b/lib/python/treadmill/rest/limit.py
@@ -1,0 +1,24 @@
+"""REST request rate limit decorators module."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import flask_limiter
+import flask_limiter.util
+
+
+def wrap(app, rule):
+    """Wrap flask app with rule based request rate control.
+    """
+    limiter = flask_limiter.Limiter(
+        app,
+        key_func=flask_limiter.util.get_remote_address,
+    )
+    decorator = limiter.shared_limit(rule, '_global')
+
+    for endpoint, func in app.view_functions.items():
+        app.view_functions[endpoint] = decorator(func)
+
+    return app

--- a/lib/python/treadmill/restclient.py
+++ b/lib/python/treadmill/restclient.py
@@ -193,8 +193,8 @@ def _call(url, method, payload=None, headers=None, auth=None,
         _LOGGER.debug(
             'Response[%d] - %s',
             response.status_code,
-            (response.text if len(response.text) <= _DEBUG_TXT_LEN
-             else '{}...'.format(response.text[:_DEBUG_TXT_LEN]))
+            (response.content if len(response.content) <= _DEBUG_TXT_LEN
+             else '{}...'.format(response.content[:_DEBUG_TXT_LEN]))
         )
     except requests.exceptions.ConnectionError:
         _LOGGER.debug('Connection error: %r', url)

--- a/lib/python/treadmill/runtime/docker/runtime.py
+++ b/lib/python/treadmill/runtime/docker/runtime.py
@@ -212,6 +212,25 @@ def _update_network_info_in_manifest(container, manifest):
     }
 
 
+def _create_docker_log_symlink(svc_data_dir):
+    """ crete a app/data/service/log link which points to app/log/
+        :param app_data_dir:
+            app/data path
+    """
+    docker_data_dir = os.path.join(
+        os.path.realpath(svc_data_dir),
+        'services',
+        'docker',
+        'data'
+    )
+
+    fs.mkdir_safe(docker_data_dir)
+    link = os.path.join(docker_data_dir, 'log')
+    target = os.path.join(svc_data_dir, 'log')
+    _LOGGER.info('linking %s -> %s', link, target)
+    fs.symlink_safe(link, target)
+
+
 def _check_aborted(container_dir):
     """check if app was aborted and why.
     """
@@ -295,6 +314,8 @@ class DockerRuntime(runtime_base.RuntimeBase):
             log.info('container_data %r', container_data_dir)
 
             fs.mkdir_safe(container_data_dir)
+
+            _create_docker_log_symlink(self._service.data_dir)
 
             # volume mapping config : read-only mapping
             volume_mapping = {

--- a/lib/python/treadmill/sproc/nodeinfo.py
+++ b/lib/python/treadmill/sproc/nodeinfo.py
@@ -11,6 +11,7 @@ import os
 import socket
 
 import click
+import limits
 
 from treadmill import appenv
 from treadmill import cli
@@ -25,8 +26,18 @@ from treadmill import zkutils
 from treadmill.rest import api
 from treadmill.rest import error_handlers  # pylint: disable=W0611
 
-
 _LOGGER = logging.getLogger(__name__)
+
+
+def _validate_rate_limit(_ctx, _param, value):
+    """Validate rate limit string."""
+    if value is None:
+        return None
+    try:
+        limits.parse_many(value)
+    except ValueError:
+        raise click.BadParameter('Rate limit format: n/second, m/minute, etc.')
+    return value
 
 
 def init():
@@ -46,8 +57,11 @@ def init():
     @click.option('-t', '--title', help='API Doc Title',
                   default='Treadmill Nodeinfo REST API')
     @click.option('-c', '--cors-origin', help='CORS origin REGEX')
+    @click.option('--rate-limit',
+                  required=False, callback=_validate_rate_limit,
+                  help='API request rate limit rule (eg. "5/second")')
     def server(approot, register, port, auth, modules, config, title,
-               cors_origin):
+               cors_origin, rate_limit):
         """Runs nodeinfo server."""
         if port == 0:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -116,7 +130,8 @@ def init():
             )
 
         rest_server = rest.TcpRestServer(port, auth_type=auth,
-                                         protect=api_paths)
+                                         protect=api_paths,
+                                         rate_limit=rate_limit)
         rest_server.run()
 
     return server

--- a/lib/python/treadmill/syscall/krb5.py
+++ b/lib/python/treadmill/syscall/krb5.py
@@ -13,6 +13,7 @@ from __future__ import unicode_literals
 
 import os
 import logging
+import platform
 import ctypes
 
 from ctypes import (
@@ -28,8 +29,21 @@ from ctypes.util import find_library
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _get_gssapi_path():
+    if os.name == 'nt':
+        if platform.architecture()[0] == '64bit':
+            lib_name = 'krb5_64'
+        else:
+            lib_name = 'krb5_32'
+    else:
+        lib_name = 'gssapi_krb5'
+
+    return find_library(lib_name)
+
+
 try:
-    _GSSAPI_PATH = find_library('gssapi_krb5')
+    _GSSAPI_PATH = _get_gssapi_path()
     _GSSAPI = ctypes.CDLL(_GSSAPI_PATH, use_errno=True)
 except Exception:  # pylint: disable=W0703
     _GSSAPI = None

--- a/lib/python/treadmill/tests/admin_test.py
+++ b/lib/python/treadmill/tests/admin_test.py
@@ -910,7 +910,7 @@ class AllocationTest(unittest.TestCase):
             attributes=mock.ANY,
             search_base='allocation=prod1,tenant=bar,tenant=foo,'
                         'ou=allocations,ou=treadmill,dc=xx,dc=com',
-            search_filter='(objectclass=tmCellAllocation)',
+            search_filter='(&(objectclass=tmCellAllocation))',
             dirty=False
         )
         self.assertEqual(obj['reservations'][0]['cell'], 'xxx')

--- a/lib/python/treadmill/tests/appcfg/docker_feature_test.py
+++ b/lib/python/treadmill/tests/appcfg/docker_feature_test.py
@@ -20,6 +20,7 @@ class AppCfgDockerFeatureTest(unittest.TestCase):
     """
 
     @mock.patch('treadmill.subproc.resolve', mock.Mock(return_value='tm'))
+    @mock.patch('treadmill.utils.get_ulimit', mock.Mock(return_value=(0, 0)))
     @mock.patch('treadmill.appcfg.features.docker._get_docker_registry',
                 mock.Mock(return_value=iter(['foo:5050', 'bar:5050'])))
     def test_docker_feature(self):
@@ -56,6 +57,13 @@ class AppCfgDockerFeatureTest(unittest.TestCase):
              ' --exec-opt native.cgroupdriver=cgroupfs --bridge=none'
              ' --ip-forward=false --ip-masq=false --iptables=false'
              ' --cgroup-parent=docker --block-registry="*"'
+             ' --default-ulimit core=0:0'
+             ' --default-ulimit data=0:0'
+             ' --default-ulimit fsize=0:0'
+             ' --default-ulimit nproc=0:0'
+             ' --default-ulimit nofile=0:0'
+             ' --default-ulimit rss=0:0'
+             ' --default-ulimit stack=0:0'
              ' --insecure-registry foo:5050 --add-registry foo:5050'
              ' --insecure-registry bar:5050 --add-registry bar:5050')
         )

--- a/lib/python/treadmill/tests/dockerutils_test.py
+++ b/lib/python/treadmill/tests/dockerutils_test.py
@@ -1,0 +1,63 @@
+"""Unit test for treadmill.dockerutils
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+import mock
+
+# Disable W0611: Unused import
+import treadmill.tests.treadmill_test_skip_windows  # pylint: disable=W0611
+
+from treadmill import dockerutils
+
+
+class DockerUtilsTest(unittest.TestCase):
+    """Test treadmill common docker utils
+    """
+
+    @mock.patch('resource.getrlimit')
+    def test_init_ulimit(self, mock_getrlimit):
+        """test ulimit init method
+        """
+        mock_getrlimit.return_value = (1, 2)
+
+        # pylint: disable=protected-access
+        self.assertEqual(
+            dockerutils.init_ulimit([]),
+            [
+                {'Name': 'core', 'Soft': 1, 'Hard': 2},
+                {'Name': 'data', 'Soft': 1, 'Hard': 2},
+                {'Name': 'fsize', 'Soft': 1, 'Hard': 2},
+                {'Name': 'nproc', 'Soft': 1, 'Hard': 2},
+                {'Name': 'nofile', 'Soft': 1, 'Hard': 2},
+                {'Name': 'rss', 'Soft': 1, 'Hard': 2},
+                {'Name': 'stack', 'Soft': 1, 'Hard': 2},
+            ]
+        )
+        mock_getrlimit.assert_has_calls([
+            mock.call(4),   # RLIMIT_CORE
+            mock.call(2),   # RLIMIT_DATA
+            mock.call(1),   # RLIMIT_FSIZE
+            mock.call(6),   # RLIMIT_NPROC
+            mock.call(7),   # RLIMIT_NOFILE
+            mock.call(5),   # RLIMIT_RSS
+            mock.call(3),   # RLIMIT_STACK
+        ])
+        # self.assertEqual(sproc_docker._init_ulimit(None), [])
+        self.assertEqual(
+            dockerutils.init_ulimit(['nofile:10:10', 'core:20:20']),
+            [
+                {'Name': 'core', 'Soft': 20, 'Hard': 20},
+                {'Name': 'data', 'Soft': 1, 'Hard': 2},
+                {'Name': 'fsize', 'Soft': 1, 'Hard': 2},
+                {'Name': 'nproc', 'Soft': 1, 'Hard': 2},
+                {'Name': 'nofile', 'Soft': 10, 'Hard': 10},
+                {'Name': 'rss', 'Soft': 1, 'Hard': 2},
+                {'Name': 'stack', 'Soft': 1, 'Hard': 2},
+            ]
+        )

--- a/lib/python/treadmill/tests/rest/limit_test.py
+++ b/lib/python/treadmill/tests/rest/limit_test.py
@@ -1,0 +1,68 @@
+"""Tests for treadmill.rest.limit"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import time
+import unittest
+
+import flask
+import flask_restplus as restplus
+from six.moves import http_client
+
+from treadmill.rest import limit
+
+
+class LimitTest(unittest.TestCase):
+    """Test for treadmill.rest.limit"""
+
+    def setUp(self):
+        """Initialize the app with the corresponding limit logic."""
+        blueprint = flask.Blueprint('v1', __name__)
+        self.api = restplus.Api(blueprint)
+
+        self.app = flask.Flask(__name__)
+        self.app.testing = True
+        self.app.register_blueprint(blueprint)
+
+    def test_wrap(self):
+        """Test rule based request rate control."""
+        namespace = self.api.namespace(
+            'rrc', description='Request Rate Control REST API Test',
+        )
+
+        @namespace.route('/foo')
+        class _Foo(restplus.Resource):
+            """Request rate control resource example"""
+
+            def get(self):
+                """Get resource implement"""
+                return ''
+
+        @namespace.route('/bar')
+        class _Bar(restplus.Resource):
+            """Request rate control resource example"""
+
+            def get(self):
+                """Get resource implement"""
+                return ''
+
+        self.app = limit.wrap(self.app, '1/second')
+        client = self.app.test_client()
+
+        cases = (
+            ('/rrc/foo', http_client.OK, 0),
+            ('/rrc/foo', http_client.TOO_MANY_REQUESTS, 0),
+            ('/rrc/foo', http_client.OK, 1),
+            ('/rrc/bar', http_client.TOO_MANY_REQUESTS, 0),
+        )
+        for (url, expected, seconds) in cases:
+            time.sleep(seconds)
+            response = client.get(url)
+            self.assertEqual(response.status_code, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/python/treadmill/tests/runtime/docker/runtime_test.py
+++ b/lib/python/treadmill/tests/runtime/docker/runtime_test.py
@@ -109,6 +109,8 @@ class DockerRuntimeTest(unittest.TestCase):
     @mock.patch('docker.DockerClient', autospec=True)
     @mock.patch('multiprocessing.cpu_count', mock.Mock(return_value=4))
     @mock.patch('treadmill.runtime.docker.runtime._get_gmsa', mock.Mock())
+    @mock.patch('treadmill.runtime.docker.runtime._create_docker_log_symlink',
+                mock.Mock())
     def test__create_container(self, client):
         """Tests creating a docker container using the api."""
 

--- a/lib/python/treadmill/tests/sproc/docker_test.py
+++ b/lib/python/treadmill/tests/sproc/docker_test.py
@@ -90,43 +90,6 @@ class DockerTest(unittest.TestCase):
             ],
         )
 
-    @mock.patch('resource.getrlimit')
-    def test__init_ulimit(self, mock_getrlimit):
-        """test ulimit init method
-        """
-        mock_getrlimit.return_value = (1, 2)
-
-        # pylint: disable=protected-access
-        self.assertEqual(
-            sproc_docker._init_ulimit([]),
-            [
-                {'Name': 'core', 'Soft': 1, 'Hard': 2},
-                {'Name': 'data', 'Soft': 1, 'Hard': 2},
-                {'Name': 'fsize', 'Soft': 1, 'Hard': 2},
-                {'Name': 'nproc', 'Soft': 1, 'Hard': 2},
-                {'Name': 'nofile', 'Soft': 1, 'Hard': 2},
-                {'Name': 'rss', 'Soft': 1, 'Hard': 2},
-                {'Name': 'stack', 'Soft': 1, 'Hard': 2},
-            ]
-        )
-        mock_getrlimit.assert_has_calls([
-            mock.call(4),   # RLIMIT_CORE
-            mock.call(2),   # RLIMIT_DATA
-            mock.call(1),   # RLIMIT_FSIZE
-            mock.call(6),   # RLIMIT_NPROC
-            mock.call(7),   # RLIMIT_NOFILE
-            mock.call(5),   # RLIMIT_RSS
-            mock.call(3),   # RLIMIT_STACK
-        ])
-        # self.assertEqual(sproc_docker._init_ulimit(None), [])
-        self.assertEqual(
-            sproc_docker._init_ulimit(['nofile:1:1', 'core:2:2']),
-            [
-                {'Name': 'nofile', 'Soft': 1, 'Hard': 1},
-                {'Name': 'core', 'Soft': 2, 'Hard': 2},
-            ]
-        )
-
     def test__parse_image_name(self):
         """test parse image name string
         """

--- a/lib/python/treadmill/tests/sproc/nodeinfo_test.py
+++ b/lib/python/treadmill/tests/sproc/nodeinfo_test.py
@@ -1,0 +1,41 @@
+"""Unit test for treadmill.sproc.nodeinfo."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+import click
+
+from treadmill.sproc import nodeinfo
+
+
+class NodeinfoTest(unittest.TestCase):
+    """Test treadmill.sproc.nodeinfo."""
+
+    def test_validate_rate_limit(self):
+        """Test nodeinfo._validate_rate_limit."""
+        # pylint: disable=W0212
+        self.assertIsNone(nodeinfo._validate_rate_limit(None, None, None))
+
+        valid_rules = [
+            '1/second', '2/minute;3/hour', '4/day,5/month', '6 per second',
+            '7 per hour|8/day',
+        ]
+        for rule in valid_rules:
+            actual = nodeinfo._validate_rate_limit(None, None, rule)
+            self.assertEqual(rule, actual)
+
+        invalid_rules = [
+            '', 'x/second', '/hour', 'per day', 'permonth', '1 second',
+            '-2/hour', '3/day;4 hour',
+        ]
+        for rule in invalid_rules:
+            with self.assertRaises(click.BadParameter):
+                nodeinfo._validate_rate_limit(None, None, rule)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ decorator>=4.0,<4.3
 dnspython>=1.15,<2
 docker>=3.3
 Flask-RESTful>=0.3,<1
+flask-limiter>=1.0.1,<2
 flask-restplus>=0.10,<1
 Flask>=0.12,<1
 gevent>=1.1
@@ -14,7 +15,7 @@ Jinja2>=2.9,<3
 jsonschema>=2.5,<3
 kazoo>=2.2,<3
 ldap3>=2.3,<3
-netifaces>=0.10,<0.11
+netifaces>=0.10,<0.11,!=0.10.8
 Numpy>=1.13,<2
 pandas>=0.19,<1
 parse>=1.8,<2


### PR DESCRIPTION
 * Add ulimit configuration to dockerd feature
 * Make --details default in show finished.
 * Handle bulk_delete with an empty list
 * Skipping netifaces v.0.10.8 due to broken upstream build
 * Allow to pass manifest in stdin to treadmill configure.
 * Fix allocation assignment
 * do not decode http response content in debug
 * Implement request rate control for nodeinfo apis
 * Allow passing manifest from stdin in treadmill run.
 * Do not display subtenants' info when querying.
 * Fix krb5 for windows