### PR TITLE
Sync with 2019.03.19-1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ recursive-include lib/python/treadmill/bootstrap/node/linux *
 recursive-include lib/python/treadmill/bootstrap/node/windows *
 recursive-include lib/python/treadmill/bootstrap/openldap/linux *
 recursive-include lib/python/treadmill/bootstrap/spawn/linux *
+recursive-include lib/python/treadmill/bootstrap/tkt_fwd/linux *
 recursive-include lib/python/treadmill/bootstrap/zookeeper/linux *
 # Treadmill resources
 recursive-include lib/python/treadmill/etc/ldap *

--- a/entry_points.txt
+++ b/entry_points.txt
@@ -253,6 +253,7 @@ host-ring = treadmill.sproc.host_ring
 init = treadmill.sproc.init
 kernel-watchdog = treadmill.sproc.kernel_watchdog
 keytabs = treadmill.sproc.keytabs
+keytabs2 = treadmill.sproc.keytabs2
 metrics = treadmill.sproc.metrics
 monitor = treadmill.sproc.monitor
 nodeinfo = treadmill.sproc.nodeinfo

--- a/lib/python/treadmill/admin/__init__.py
+++ b/lib/python/treadmill/admin/__init__.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 import logging
 from ldap3.core import exceptions as ldap_exceptions
 
-from . import _ldap
 from . import exc
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,70 +18,76 @@ _LOGGER = logging.getLogger(__name__)
 # Once all usage is updated to the new API, _wrap_excs should be moved
 # to _ldap and everything else should be removed.
 
-# Disable warning about fake constructors
-# pylint: disable=invalid-name
-
 def Partition(backend):
     """Fake constructor for backward compatiblity.
     """
+    # pylint: disable=invalid-name
     _LOGGER.debug('Using deprecated admin interface.')
-    return _ldap.Partition(backend.conn)
+    return backend.partition()
 
 
 def Allocation(backend):
     """Fake constructor for backward compatiblity.
     """
+    # pylint: disable=invalid-name
     _LOGGER.debug('Using deprecated admin interface.')
-    return _ldap.Allocation(backend.conn)
+    return backend.allocation()
 
 
 def CellAllocation(backend):
     """Fake constructor for backward compatiblity.
     """
+    # pylint: disable=invalid-name
     _LOGGER.debug('Using deprecated admin interface.')
-    return _ldap.CellAllocation(backend.conn)
+    return backend.cell_allocation()
 
 
 def Tenant(backend):
     """Fake constructor for backward compatiblity.
     """
+    # pylint: disable=invalid-name
     _LOGGER.debug('Using deprecated admin interface.')
-    return _ldap.Tenant(backend.conn)
+    return backend.tenant()
 
 
 def Cell(backend):
     """Fake constructor for backward compatiblity.
     """
+    # pylint: disable=invalid-name
     _LOGGER.debug('Using deprecated admin interface.')
-    return _ldap.Cell(backend.conn)
+    return backend.cell()
 
 
 def Server(backend):
     """Fake constructor for backward compatiblity.
     """
+    # pylint: disable=invalid-name
     _LOGGER.debug('Using deprecated admin interface.')
-    return _ldap.Server(backend.conn)
+    return backend.server()
 
 
 def Application(backend):
     """Fake constructor for backward compatiblity.
     """
+    # pylint: disable=invalid-name
     _LOGGER.debug('Using deprecated admin interface.')
-    return _ldap.Application(backend.conn)
+    return backend.application()
 
 
 def AppGroup(backend):
     """Fake constructor for backward compatiblity.
     """
+    # pylint: disable=invalid-name
     _LOGGER.debug('Using deprecated admin interface.')
-    return _ldap.AppGroup(backend.conn)
+    return backend.app_group()
 
 
 def DNS(backend):
     """Fake constructor for backward compatiblity.
     """
+    # pylint: disable=invalid-name
     _LOGGER.debug('Using deprecated admin interface.')
-    return _ldap.DNS(backend.conn)
+    return backend.dns()
 
 
 def _wrap_excs(func):
@@ -92,16 +97,16 @@ def _wrap_excs(func):
         """Wrapper that does the exception translation."""
         try:
             return func(*args, **kwargs)
-        except ldap_exceptions.LDAPNoSuchObjectResult as e:
-            raise exc.NoSuchObjectResult(e)
-        except ldap_exceptions.LDAPEntryAlreadyExistsResult as e:
-            raise exc.AlreadyExistsResult(e)
-        except ldap_exceptions.LDAPBindError as e:
-            raise exc.AdminConnectionError(e)
-        except ldap_exceptions.LDAPInsufficientAccessRightsResult as e:
-            raise exc.AdminAuthorizationError(e)
-        except ldap_exceptions.LDAPOperationResult as e:
-            raise exc.AdminBackendError(e)
+        except ldap_exceptions.LDAPNoSuchObjectResult as err:
+            raise exc.NoSuchObjectResult(err)
+        except ldap_exceptions.LDAPEntryAlreadyExistsResult as err:
+            raise exc.AlreadyExistsResult(err)
+        except ldap_exceptions.LDAPBindError as err:
+            raise exc.AdminConnectionError(err)
+        except ldap_exceptions.LDAPInsufficientAccessRightsResult as err:
+            raise exc.AdminAuthorizationError(err)
+        except ldap_exceptions.LDAPOperationResult as err:
+            raise exc.AdminBackendError(err)
 
     return wrapper
 
@@ -116,12 +121,13 @@ class WrappedAdmin():
 
     def dn(self, ident):
         """Constructs dn."""
+        # pylint: disable=invalid-name
         return self._conn.dn(ident)
 
     @_wrap_excs
-    def get(self, dn, query, attrs, **kwargs):
+    def get(self, entry_dn, query, attrs, **kwargs):
         """Gets LDAP object given dn."""
-        return self._conn.get(dn, query, attrs, **kwargs)
+        return self._conn.get(entry_dn, query, attrs, **kwargs)
 
     @_wrap_excs
     def paged_search(self, search_base, search_filter, **kwargs):
@@ -130,21 +136,21 @@ class WrappedAdmin():
         return self._conn.paged_search(search_base, search_filter, **kwargs)
 
     @_wrap_excs
-    def create(self, dn, entry):
+    def create(self, entry_dn, entry):
         """Creates LDAP record."""
-        return self._conn.create(dn, entry)
+        return self._conn.create(entry_dn, entry)
 
     @_wrap_excs
-    def update(self, dn, entry):
+    def update(self, entry_dn, entry):
         """Updates LDAP record."""
-        return self._conn.update(dn, entry)
+        return self._conn.update(entry_dn, entry)
 
     @_wrap_excs
-    def remove(self, dn, entry):
+    def remove(self, entry_dn, entry):
         """Removes attributes from the record."""
-        return self._conn.remove(dn, entry)
+        return self._conn.remove(entry_dn, entry)
 
     @_wrap_excs
-    def delete(self, dn):
+    def delete(self, entry_dn):
         """Call ldap delete and raise exception on non-success."""
-        return self._conn.delete(dn)
+        return self._conn.delete(entry_dn)

--- a/lib/python/treadmill/admin/_ldap.py
+++ b/lib/python/treadmill/admin/_ldap.py
@@ -16,7 +16,7 @@ import logging
 import shlex
 
 import ldap3
-from ldap3.core import exceptions as ldap_exceptions
+import ldap3.core.exceptions as ldap_exceptions
 import jinja2
 import six
 
@@ -602,10 +602,17 @@ class Admin:
                 )
             )
 
-    def search(self, search_base, search_filter,
+    def search(self, search_base=None, search_filter=None,
                search_scope=ldap3.SUBTREE, attributes=None, dirty=False):
         """Call ldap search and return a generator of dn, entry tuples.
         """
+        if search_base is None:
+            search_base = self.root_ou
+        if search_filter is None:
+            search_filter = '(objectClass=*)'
+        if attributes is None:
+            attributes = ['*', '+']
+
         # If entries in the potential search results were written or modified
         # recently, we use the connection to the write server to avoid problems
         # with replication delays between provider and consumer
@@ -621,13 +628,22 @@ class Admin:
         )
         self._test_raise_exceptions(ldap)
 
-        for entry in ldap.response:
-            yield entry['dn'], entry['attributes']
+        return iter(ldap.response)
 
-    def paged_search(self, search_base, search_filter,
+    def paged_search(self, search_base=None, search_filter=None,
                      search_scope=ldap3.SUBTREE, attributes=None, dirty=False):
         """Call ldap paged search and return a generator of dn, entry tuples.
+
+        :returns:
+            ``generator`` - Search result generator
         """
+        if search_base is None:
+            search_base = self.root_ou
+        if search_filter is None:
+            search_filter = '(objectClass=*)'
+        if attributes is None:
+            attributes = ['*', '+']
+
         # If entries in the potential search results were written or modified
         # recently, we use the connection to the write server to avoid problems
         # with replication delays between provider and consumer
@@ -646,8 +662,7 @@ class Admin:
         )
         self._test_raise_exceptions(ldap)
 
-        for entry in res_gen:
-            yield entry['dn'], entry['attributes']
+        return res_gen
 
     def _test_raise_exceptions(self, ldap=None):
         """
@@ -698,17 +713,6 @@ class Admin:
         self.write_ldap.delete(dn)
         self._test_raise_exceptions(self.write_ldap)
 
-    def list(self, root=None, dirty=False):
-        """Lists all objects in the database."""
-        if not root:
-            root = self.root_ou
-        result = self.paged_search(
-            search_base=root,
-            search_filter='(objectClass=*)',
-            dirty=dirty
-        )
-        return [dn for dn, _ in result]
-
     def schema(self, abstract=True):
         """Get schema."""
         # Disable too many branches warning.
@@ -722,13 +726,14 @@ class Admin:
                              attributes=['olcAttributeTypes',
                                          'olcObjectClasses'])
 
-        try:
-            schema_dn, entry = next(result)
-        except StopIteration:
+        entry = next(result, None)
+        if entry is None:
             return None
 
+        schema_dn, schema = entry['dn'], entry['attributes']
+
         attr_types = []
-        for attr_type_s in entry.get('olcAttributeTypes', []):
+        for attr_type_s in schema.get('olcAttributeTypes', []):
             # Split preserving quotes.
             attr_type_l = shlex.split(attr_type_s)
             # Remove leading and closing bracket.
@@ -780,7 +785,7 @@ class Admin:
                     return result
                 assert sep == '$'
 
-        for obj_cls_s in entry.get('olcObjectClasses', []):
+        for obj_cls_s in schema.get('olcObjectClasses', []):
             # Split preserving quotes.
             obj_cls_l = shlex.split(obj_cls_s)
             # Remove leading and closing bracket.
@@ -1013,10 +1018,7 @@ class Admin:
                              attributes=attrs,
                              dirty=dirty)
 
-        for _dn, entry in result:
-            return entry
-
-        return None
+        return next(iter(result), {}).get('attributes')
 
     def create(self, dn, entry):
         """Creates LDAP record."""
@@ -1035,11 +1037,23 @@ class Admin:
         old_entry = self.get(
             dn,
             '(objectClass=*)',
-            _entry_plain_keys(new_entry)
+            _entry_plain_keys(new_entry),
+            dirty=True
         )
         diff = _diff_entries(old_entry, new_entry)
-
         self.modify(dn, diff)
+
+    def set(self, entry_dn, entry_data):
+        """Create or update and LDAP record.
+        """
+        try:
+            self.add(
+                entry_dn, attributes=entry_data
+            )
+        except ldap_exceptions.LDAPEntryAlreadyExistsResult:
+            self.update(
+                entry_dn, entry_data
+            )
 
     def remove(self, dn, entry):
         """Removes attributes from the record."""
@@ -1049,8 +1063,11 @@ class Admin:
         self.modify(dn, to_be_removed)
 
     def get_repls(self):
-        """Get replication information."""
-        # paged_search does not work with config backend, so using low level
+        """Get replication information.
+
+        NOTE: OpenLDAP specific
+        """
+        # paged_search does not work with cn=config backend, so using low level
         # search instead of higher level wrappers.
         result = self.search(
             search_base='olcDatabase={1}mdb,cn=config',
@@ -1058,8 +1075,11 @@ class Admin:
             attributes=['olcSyncrepl'],
             search_scope=ldap3.BASE,
         )
-        for _dn, entry in result:
+        entry = next(iter(result), {}).get('attributes')
+        if entry:
             return entry.get('olcSyncrepl')
+        else:
+            return None
 
 
 class LdapObject:
@@ -1068,12 +1088,22 @@ class LdapObject:
     # Allow such names as 'dn', 'ou'
     # pylint: disable=invalid-name
 
+    _operational_attrs = ['createTimestamp', 'modifyTimestamp']
+
     def __init__(self, admin):
         self.admin = admin
 
     def from_entry(self, entry, _dn=None):
         """Converts ldap entry to dict."""
-        return _entry_2_dict(entry, self.schema())
+        obj = _entry_2_dict(entry, self.schema())
+
+        # Add operational attrs if they were requested, those can only be read.
+        # create/modifyTimestamp are single-valued, UTC aware datetime objects.
+        if entry.get('createTimestamp'):
+            obj['_create_timestamp'] = entry['createTimestamp'].timestamp()
+        if entry.get('modifyTimestamp'):
+            obj['_modify_timestamp'] = entry['modifyTimestamp'].timestamp()
+        return obj
 
     def to_entry(self, obj):
         """Converts object to LDAP entry."""
@@ -1097,10 +1127,13 @@ class LdapObject:
 
         return dn
 
-    def get(self, ident, dirty=False):
+    def get(self, ident, dirty=False, get_operational_attrs=False):
         """Gets object given identity."""
+        attrs = self.attrs()
+        if get_operational_attrs:
+            attrs += self._operational_attrs
         entry = self.admin.get(
-            self.dn(ident), self._query(), self.attrs(), dirty=dirty,
+            self.dn(ident), self._query(), attrs, dirty=dirty,
         )
         if entry:
             return self.from_entry(entry, self.dn(ident))
@@ -1120,7 +1153,8 @@ class LdapObject:
 
         self.admin.create(self.dn(ident), entry)
 
-    def list(self, attrs, generator=False, dirty=False):
+    def list(self, attrs, generator=False, dirty=False,
+             get_operational_attrs=False):
         """List records, given attribute filter."""
         query = self._query()
         for ldap_field, obj_field, _field_type in self.schema():
@@ -1136,16 +1170,27 @@ class LdapObject:
                     query(arg, value)
             else:
                 query(arg, attrs[obj_field])
-
         _LOGGER.debug('Query: %s', query.to_str())
+
+        attributes = self.attrs()
+        if get_operational_attrs:
+            attributes += self._operational_attrs
+
         result = self.admin.paged_search(search_base=self.dn(),
                                          search_filter=query.to_str(),
                                          search_scope=ldap3.SUBTREE,
-                                         attributes=self.attrs(),
+                                         attributes=attributes,
                                          dirty=dirty)
         if generator:
-            return (self.from_entry(entry, dn) for dn, entry in result)
-        return [self.from_entry(entry, dn) for dn, entry in result]
+            return (
+                self.from_entry(entry['attributes'], entry['dn'])
+                for entry in result
+            )
+        else:
+            return [
+                self.from_entry(entry['attributes'], entry['dn'])
+                for entry in result
+            ]
 
     def update(self, ident, attrs):
         """Updates LDAP record."""
@@ -1185,8 +1230,8 @@ class LdapObject:
             dirty=dirty
         )
         return [
-            children_admin.from_entry(entry, child_dn)
-            for child_dn, entry in children
+            children_admin.from_entry(entry['attributes'], entry['dn'])
+            for entry in children
         ]
 
 
@@ -1259,9 +1304,12 @@ class AppGroup(LdapObject):
     _entity = 'app-group'
 
     # pylint: disable=arguments-differ
-    def get(self, ident, group_type=None, dirty=False):
+    def get(self, ident, group_type=None, dirty=False,
+            get_operational_attrs=False):
         """Gets object given identity and group_type"""
-        entry = super(AppGroup, self).get(ident, dirty)
+        entry = super(AppGroup, self).get(
+            ident, dirty, get_operational_attrs=get_operational_attrs
+        )
         if entry and group_type and entry['group-type'] != group_type:
             return None
 
@@ -1575,9 +1623,11 @@ class Cell(LdapObject):
             [_name_only(e) for e in Cell._master_host_schema]
         )
 
-    def get(self, ident, dirty=False):
+    def get(self, ident, dirty=False, get_operational_attrs=False):
         """Gets cell given primary key."""
-        obj = super(Cell, self).get(ident, dirty=dirty)
+        obj = super(Cell, self).get(
+            ident, dirty=dirty, get_operational_attrs=get_operational_attrs
+        )
         obj['partitions'] = self.partitions(ident, dirty=dirty)
         return obj
 
@@ -1623,8 +1673,8 @@ class Cell(LdapObject):
             attributes=[]
         )
 
-        for dn, _entry in cell_partitions:
-            self.admin.delete(dn)
+        for entry in cell_partitions:
+            self.admin.delete(entry['dn'])
 
         return super(Cell, self).delete(ident)
 
@@ -1853,9 +1903,11 @@ class Allocation(LdapObject):
         """Returns combined schema for retrieval."""
         return Allocation._schema
 
-    def get(self, ident, dirty=False):
+    def get(self, ident, dirty=False, get_operational_attrs=False):
         """Gets allocation given primary key."""
-        obj = super(Allocation, self).get(ident, dirty=dirty)
+        obj = super(Allocation, self).get(
+            ident, dirty=dirty, get_operational_attrs=get_operational_attrs
+        )
         obj['reservations'] = self.reservations(ident, dirty=dirty)
         return obj
 
@@ -1868,8 +1920,8 @@ class Allocation(LdapObject):
             attributes=[]
         )
 
-        for dn, _entry in cell_allocs_search:
-            self.admin.delete(dn)
+        for entry in cell_allocs_search:
+            self.admin.delete(entry['dn'])
 
         return super(Allocation, self).delete(ident)
 

--- a/lib/python/treadmill/admin/ldapbackend.py
+++ b/lib/python/treadmill/admin/ldapbackend.py
@@ -6,17 +6,25 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
+
 from . import _ldap
 from . import base
 from . import WrappedAdmin
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class AdminLdapBackend(base.Backend):
-    """Admin LDAP backend."""
+    """Admin LDAP backend.
+    """
+    __slots__ = (
+        '_ldap_conn',
+    )
 
     def __init__(self, uri, ldap_suffix,
                  user=None, password=None, connect_timeout=5, write_uri=None):
-        self.conn = _ldap.Admin(
+        self._ldap_conn = _ldap.Admin(
             uri, ldap_suffix,
             user=user, password=password,
             connect_timeout=connect_timeout, write_uri=write_uri
@@ -24,52 +32,113 @@ class AdminLdapBackend(base.Backend):
 
     def init(self):
         """Initializes treadmill ldap namespace."""
-        return self.conn.init()
+        return self._ldap_conn.init()
 
     def schema(self):
         """Get schema."""
-        return self.conn.schema()
+        return self._ldap_conn.schema()
 
     def update_schema(self, new_schema):
         """Safely update schema, preserving existing attribute types."""
-        return self.conn.update_schema(new_schema)
+        return self._ldap_conn.update_schema(new_schema)
 
+    def list(self, search_base=None, search_filter=None, dirty=False):
+        """List all objects DN in the admin backend.
+        """
+        search_res = self._ldap_conn.paged_search(
+            search_base=search_base,
+            search_filter=search_filter,
+            search_scope='SUBTREE',
+            attributes=[],
+            dirty=dirty
+        )
+        return [entry['dn'] for entry in search_res]
+
+    def get(self, entry_dn, search_filter=None, attributes=None, dirty=False):
+        """Return the raw data of a given ldap backend entry.
+
+        :returns:
+            ``tuple(str, dict)`` - (DN, Dict) of the request entry or None.
+        """
+        search_res = self._ldap_conn.paged_search(
+            search_base=entry_dn,
+            search_filter=search_filter,
+            search_scope='BASE',
+            attributes=attributes,
+            dirty=dirty
+        )
+        entry = next(search_res, None)
+        if entry:
+            return entry['raw_attributes']
+        else:
+            return None
+
+    def set(self, entry_dn, entry_data):
+        """Set a DN to the given entry_data
+        """
+        self._ldap_conn.set(entry_dn, entry_data)
+
+    def delete(self, entry_dn):
+        """Delete a given entry.
+        """
+        self._ldap_conn.delete(entry_dn)
+
+    def search(self, search_base=None, search_filter=None,
+               search_scope='SUBTREE', attributes=None, dirty=False):
+        """Raw search operation.
+
+        :returns:
+            ``[(dn, dict)]`` - Generator of dn and their data.
+        """
+        search_res = self._ldap_conn.paged_search(
+            search_base=search_base,
+            search_filter=search_filter,
+            search_scope=search_scope,
+            attributes=attributes,
+            dirty=dirty
+        )
+        return [
+            (entry['dn'], entry['raw_attributes'])
+            for entry in search_res
+        ]
+
+    # Base abstract method implementations below
     def connect(self):
         """Connect to backend server."""
-        self.conn.connect()
+        self._ldap_conn.connect()
 
     def partition(self):
         """Create Partition object."""
-        return _ldap.Partition(WrappedAdmin(self.conn))
+        return _ldap.Partition(WrappedAdmin(self._ldap_conn))
 
     def allocation(self):
         """Create Allocation object."""
-        return _ldap.Allocation(WrappedAdmin(self.conn))
+        return _ldap.Allocation(WrappedAdmin(self._ldap_conn))
 
     def cell_allocation(self):
         """Create CellAllocation object."""
-        return _ldap.CellAllocation(WrappedAdmin(self.conn))
+        return _ldap.CellAllocation(WrappedAdmin(self._ldap_conn))
 
     def tenant(self):
         """Create Tenant object."""
-        return _ldap.Tenant(WrappedAdmin(self.conn))
+        return _ldap.Tenant(WrappedAdmin(self._ldap_conn))
 
     def cell(self):
         """Create Cell object."""
-        return _ldap.Cell(WrappedAdmin(self.conn))
+        return _ldap.Cell(WrappedAdmin(self._ldap_conn))
 
     def application(self):
         """Create Application object."""
-        return _ldap.Application(WrappedAdmin(self.conn))
+        return _ldap.Application(WrappedAdmin(self._ldap_conn))
 
     def app_group(self):
         """Create AppGroup object."""
-        return _ldap.AppGroup(WrappedAdmin(self.conn))
+        return _ldap.AppGroup(WrappedAdmin(self._ldap_conn))
 
     def dns(self):
         """Create DNS object."""
-        return _ldap.DNS(WrappedAdmin(self.conn))
+        return _ldap.DNS(WrappedAdmin(self._ldap_conn))
 
     def server(self):
         """Create Server object."""
-        return _ldap.Server(WrappedAdmin(self.conn))
+        return _ldap.Server(WrappedAdmin(self._ldap_conn))

--- a/lib/python/treadmill/alert/__init__.py
+++ b/lib/python/treadmill/alert/__init__.py
@@ -29,14 +29,17 @@ def create(alerts_dir,
         }
     )
 
+    filename = os.path.join(alerts_dir, _to_filename(instanceid, type_))
     fs.write_safe(
-        os.path.join(alerts_dir, _to_filename(instanceid, type_)),
+        filename,
         lambda f: f.write(
             json.dumps(alert_data, indent=4).encode()
         ),
         prefix='.tmp',
-        permission=0o644
+        permission=0o644,
+        subdir='.tmp',
     )
+    return filename
 
 
 def _to_filename(instanceid, type_):

--- a/lib/python/treadmill/api/allocation.py
+++ b/lib/python/treadmill/api/allocation.py
@@ -185,8 +185,6 @@ class API:
 
     def __init__(self, plugins=None):
 
-        self._plugins = _api_plugins(plugins)
-
         def _admin_alloc():
             """Lazily return admin allocation object.
             """
@@ -426,5 +424,5 @@ class API:
         self.create = create
         self.update = update
         self.delete = delete
-        self.reservation = _ReservationAPI()
+        self.reservation = _ReservationAPI(plugins)
         self.assignment = _AssignmentAPI()

--- a/lib/python/treadmill/api/instance.py
+++ b/lib/python/treadmill/api/instance.py
@@ -53,11 +53,11 @@ def _validate(rsrc):
 def _check_required_attributes(configured):
     """Check that all required attributes are populated."""
     if 'proid' not in configured:
-        raise exc.TreadmillError(
+        raise exc.InternalError(
             'Missing required attribute: proid')
 
     if 'environment' not in configured:
-        raise exc.TreadmillError(
+        raise exc.InternalError(
             'Missing required attribute: environment')
 
 
@@ -218,7 +218,10 @@ class API:
             return masterapi.get_app(context.GLOBAL.zk.conn, rsrc_id)
 
         @schema.schema(
-            {'$ref': 'common.json#/proid'},
+            {'anyOf': [
+                {'$ref': 'common.json#/proid'},
+                {'$ref': 'common.json#/app_user'},
+            ]},
             {'type': 'array',
              'items': {'$ref': 'instance.json#/verbs/update'},
              'minItems': 1}
@@ -273,7 +276,10 @@ class API:
             )
 
         @schema.schema(
-            {'$ref': 'common.json#/proid'},
+            {'anyOf': [
+                {'$ref': 'common.json#/proid'},
+                {'$ref': 'common.json#/app_user'},
+            ]},
             {'$ref': 'instance.json#/resource_ids'},
             deleted_by={'anyOf': [
                 {'type': 'null'},

--- a/lib/python/treadmill/appcfg/configure.py
+++ b/lib/python/treadmill/appcfg/configure.py
@@ -71,9 +71,14 @@ def load_runtime_manifest(tm_env, event, runtime):
     return manifest_data
 
 
-def configure(tm_env, event, runtime):
+def configure(tm_env, event, runtime, runtime_param=None):
     """Creates directory necessary for starting the application.
-
+    :param runtime_param:
+        describe runtime paramater
+    :type runtime_param:
+        ``str list``
+        if not None contains list of 'parami=xyz' used for passing param
+         to runtime
     This operation is idem-potent (it can be repeated).
 
     The directory layout is::
@@ -115,8 +120,12 @@ def configure(tm_env, event, runtime):
 
     # Write the actual container start script
     if os.name == 'nt':
-        run_script = '{treadmill}/scripts/treadmill sproc run .'.format(
-            treadmill=subproc.resolve('treadmill'),
+        run_script = (
+            '{treadmill}/scripts/treadmill sproc run {param} .'.format(
+                treadmill=subproc.resolve('treadmill'),
+                param='--runtime-param {}'.format(','.join(runtime_param))
+                if runtime_param else '',
+            )
         )
     else:
         run_script = 'exec {treadmill}/bin/treadmill sproc run ../'.format(

--- a/lib/python/treadmill/appcfgmgr.py
+++ b/lib/python/treadmill/appcfgmgr.py
@@ -63,13 +63,16 @@ class AppCfgMgr:
         'tm_env',
         '_is_active',
         '_runtime',
+        '_runtime_param',
     )
 
-    def __init__(self, root, runtime):
-        _LOGGER.info('init appcfgmgr: %s, %s', root, runtime)
+    def __init__(self, root, runtime, runtime_param=None):
+        _LOGGER.info('init appcfgmgr: %s, %s, %s', root, runtime,
+                     runtime_param)
         self.tm_env = appenv.AppEnvironment(root=root)
         self._is_active = False
         self._runtime = runtime
+        self._runtime_param = runtime_param
 
     @property
     def name(self):
@@ -331,7 +334,8 @@ class AppCfgMgr:
             try:
                 _LOGGER.info('Configuring')
                 container_dir = app_cfg.configure(self.tm_env, event_file,
-                                                  self._runtime)
+                                                  self._runtime,
+                                                  self._runtime_param)
                 if container_dir is None:
                     # configure step failed, skip.
                     fs.rm_safe(event_file)

--- a/lib/python/treadmill/appenv/appenv.py
+++ b/lib/python/treadmill/appenv/appenv.py
@@ -12,6 +12,7 @@ import os
 
 import six
 
+from treadmill import nodedata
 from treadmill import watchdog
 
 
@@ -52,6 +53,7 @@ class AppEnvironment:
         'tombstones_dir',
         'watchdogs',
         'watchdog_dir',
+        'data',
     )
 
     ALERTS_DIR = 'alerts'
@@ -100,6 +102,8 @@ class AppEnvironment:
         self.endpoints_dir = os.path.join(self.root, self.ENDPOINTS_DIR)
 
         self.watchdogs = watchdog.Watchdog(self.watchdog_dir)
+        # Load the local config data.
+        self.data = nodedata.get(self.configs_dir)
 
     @abc.abstractmethod
     def initialize(self, params):

--- a/lib/python/treadmill/bootstrap/node/linux/init/nodeinfo.yml
+++ b/lib/python/treadmill/bootstrap/node/linux/init/nodeinfo.yml
@@ -10,6 +10,7 @@ command: |
         -m local,cgroup \
         --rate-limit '10/second' \
         --rate-limit-module cgroup=5/second \
+        --rate-limit-by user \
         --config cgroup /tmp/cgroup.cfg.yml
 environ_dir: "{{ dir }}/env"
 environ:

--- a/lib/python/treadmill/bootstrap/node/windows/init1/appcfgmgr.yml
+++ b/lib/python/treadmill/bootstrap/node/windows/init1/appcfgmgr.yml
@@ -1,5 +1,5 @@
 command: >
-  {{ treadmill }}\scripts\treadmill sproc appcfgmgr
+  {{ treadmill }}\scripts\treadmill sproc appcfgmgr {% if treadmill_runtime_param %}--runtime-param {{ treadmill_runtime_param|join(',') }} {% endif %}
 monitor_policy:
   limit: 2
   interval: 60

--- a/lib/python/treadmill/cleanup.py
+++ b/lib/python/treadmill/cleanup.py
@@ -47,6 +47,16 @@ _MAX_REQUEST_PER_CYCLE = 1
 _SERVICE_NAME = 'Cleanup'
 
 
+def _islink(path):
+    """
+    A local function wrap os.path.islink.
+    """
+    # CAVEAT : Coverage uses islink internally to determine the scope to trace.
+    # While mocking islink in unit test, coverage uses moocked islink which may
+    # potentially cause StopIterationException.
+    return os.path.islink(path)
+
+
 class Cleanup:
     """Orchestrate the cleanup of apps which are scheduled to be stopped and/or
     removed.
@@ -79,12 +89,12 @@ class Cleanup:
             return
 
         cleaning_link = os.path.join(self.tm_env.cleaning_dir, name)
-        if os.path.islink(cleaning_link):
+        if _islink(cleaning_link):
             _LOGGER.warning('Cleaning app already configured %s', name)
             return
 
         cleanup_link = os.path.join(self.tm_env.cleanup_dir, name)
-        if not os.path.islink(cleanup_link):
+        if not _islink(cleanup_link):
             _LOGGER.info('Ignore - not a link: %s', cleanup_link)
             return
 

--- a/lib/python/treadmill/cli/admin/install/node.py
+++ b/lib/python/treadmill/cli/admin/install/node.py
@@ -13,6 +13,7 @@ import click
 
 from treadmill import bootstrap
 from treadmill import context
+from treadmill import cli
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,15 +25,18 @@ def init():
     @click.command()
     @click.option('--run/--no-run', is_flag=True, default=False)
     @click.option('--runtime', envvar='TREADMILL_RUNTIME')
+    @click.option('--runtime-param', type=cli.LIST, required=False)
     @click.option('--benchmark/--no-benchmark', is_flag=True, default=False)
     @click.pass_context
-    def node(ctx, run, benchmark, runtime=None):
+    def node(ctx, run, benchmark, runtime=None, runtime_param=None):
         """Installs Treadmill node."""
         dst_dir = ctx.obj['PARAMS']['dir']
         profile = ctx.obj['PARAMS'].get('profile')
 
         if runtime is not None:
             ctx.obj['PARAMS']['treadmill_runtime'] = runtime
+
+        ctx.obj['PARAMS']['treadmill_runtime_param'] = runtime_param
 
         if os.name == 'nt':
             wipe_script = [

--- a/lib/python/treadmill/cli/admin/install/zookeeper.py
+++ b/lib/python/treadmill/cli/admin/install/zookeeper.py
@@ -12,6 +12,7 @@ import os
 import click
 
 from treadmill import bootstrap
+from treadmill import cli
 from treadmill import context
 from treadmill import sysinfo
 from treadmill.syscall import krb5
@@ -30,8 +31,12 @@ def init():
                   type=click.Path(exists=True),
                   envvar='TREADMILL_ZOOKEEPER_DATA_DIR',
                   help='Zookeeper data directory.')
+    @click.option('--zk-admins',
+                  type=cli.LIST,
+                  envvar='TREADMILL_ZOOKEEPER_ADMINS',
+                  help='Zookeeper admin roles')
     @click.pass_context
-    def zookeeper(ctx, run, master_id, data_dir):
+    def zookeeper(ctx, run, master_id, data_dir, zk_admins):
         """Installs Treadmill master."""
 
         ctx.obj['PARAMS']['zookeeper'] = context.GLOBAL.zk.url
@@ -54,6 +59,12 @@ def init():
         run_sh = None
         if run:
             run_sh = os.path.join(dst_dir, 'treadmill', 'bin', 'run.sh')
+
+        if zk_admins:
+            zk_admins.append(ctx.obj['PARAMS']['treadmillid'])
+            ctx.obj['PARAMS']['zk_admins'] = ','.join(set(zk_admins))
+        else:
+            ctx.obj['PARAMS']['zk_admins'] = ctx.obj['PARAMS']['treadmillid']
 
         bootstrap.install(
             'zookeeper',

--- a/lib/python/treadmill/cli/admin/ldap/cell.py
+++ b/lib/python/treadmill/cli/admin/ldap/cell.py
@@ -22,6 +22,8 @@ def init():
     # pylint: disable=too-many-statements
     formatter = cli.make_formatter('cell')
 
+    masters_idx = ['1', '2', '3', '4', '5']
+
     @click.group()
     @cli.admin.ON_EXCEPTIONS
     def cell():
@@ -87,7 +89,7 @@ def init():
 
     @cell.command()
     @click.option('--idx', help='Master index.',
-                  type=click.Choice(['1', '2', '3', '4', '5']),
+                  type=click.Choice(masters_idx),
                   required=True)
     @click.option('--hostname', help='Master hostname.',
                   required=True)
@@ -140,7 +142,7 @@ def init():
 
     @cell.command()
     @click.option('--idx', help='Master index.',
-                  type=click.Choice(['1', '2', '3']),
+                  type=click.Choice(masters_idx),
                   required=True)
     @click.argument('cell')
     @cli.admin.ON_EXCEPTIONS

--- a/lib/python/treadmill/cli/admin/ldap/direct.py
+++ b/lib/python/treadmill/cli/admin/ldap/direct.py
@@ -6,15 +6,21 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import click
+import collections
+import io
+import os
 
-from treadmill import admin
+import click
+import ldif3
+
 from treadmill import cli
 from treadmill import context
+from treadmill import fs
 
 
 def init():
-    """Direct ldap access CLI group"""
+    """Direct ldap access CLI group.
+    """
 
     @click.group()
     def direct():
@@ -22,45 +28,130 @@ def init():
         """
 
     @direct.command()
-    @click.option('-c', '--cls', help='Object class', required=True)
-    @click.option('-a', '--attrs', help='Addition attributes',
-                  type=cli.LIST)
-    @click.argument('rec_dn')
+    @click.option('-a', '--attrs', help='Attributes',
+                  type=cli.LIST, default=None)
+    @click.argument('entry_dn')
     @cli.admin.ON_EXCEPTIONS
-    def get(rec_dn, cls, attrs):
-        """List all defined DNs"""
-        if not attrs:
-            attrs = []
-        try:
-            # TODO: it is porbably possible to derive class from DN.
-            klass = getattr(admin, cls)
-            attrs.extend([elem[0] for elem in klass.schema()])
-        except AttributeError:
-            cli.bad_exit('Invalid admin type: %s', cls)
-            return
+    def get(entry_dn, attrs):
+        """Retreive a given entry in LDIF format.
+        """
+        entry_data = context.GLOBAL.admin.conn.get(
+            entry_dn=entry_dn,
+            attributes=attrs
+        )
+        if entry_data:
+            cli.out(_sorted_ldif_entry(entry_dn, entry_data))
 
-        entry = context.GLOBAL.ldap.conn.get(
-            rec_dn, '(objectClass=*)', list(set(attrs)))
-        formatter = cli.make_formatter(None)
-        cli.out(formatter(entry))
+    @direct.command(name='set')
+    @click.argument('ldif_file', type=click.File('rb'))
+    @cli.admin.ON_EXCEPTIONS
+    def set_(ldif_file):
+        """Load DNs and attributes from a LDIF files and set them in LDAP.
+        """
+        # We need to strip all operational attributes before putting
+        # the entry back into LDAP. We do this by retrieving and empty
+        # DN and listing which attributes it has; they will be all
+        # operational.
+        empty_item = context.GLOBAL.admin.conn.get(
+            entry_dn=None,
+            attributes=['+']
+        )
+        operational_attributes = empty_item.keys()
+        for entry_dn, entry_data in ldif3.LDIFParser(ldif_file).parse():
+            cli.out('Loading %r', entry_dn)
+            cleaned_data = {
+                k: v
+                for k, v in entry_data.items()
+                if k not in operational_attributes
+            }
+            context.GLOBAL.admin.conn.set(
+                entry_dn, cleaned_data
+            )
 
     @direct.command(name='list')
-    @click.option('--root', help='Search root.')
+    @click.option('--root', help='Search root.', default=None)
     @cli.admin.ON_EXCEPTIONS
-    def _list(root):
-        """List all defined DNs"""
-        dns = context.GLOBAL.ldap.conn.list(root)
-        for rec_dn in dns:
-            cli.out(rec_dn)
+    def list_(root):
+        """List all defined DNs.
+        """
+        entry_dns = context.GLOBAL.admin.conn.list(root)
+        for entry_dn in entry_dns:
+            cli.out(entry_dn)
+
+    @direct.command()
+    @click.option('--root', help='Search root.')
+    @click.option('-a', '--attrs', help='Attributes',
+                  type=cli.LIST, default=None)
+    @click.option('--output-dir', help='target output path.')
+    @cli.admin.ON_EXCEPTIONS
+    def dump(root, attrs, output_dir):
+        """Dump all entries below a root as a tree of LDIF file
+        """
+        entries = context.GLOBAL.admin.conn.search(
+            search_base=root,
+            attributes=attrs,
+        )
+        for entry_dn, entry_data in entries:
+            cli.out('dn: {dn}'.format(dn=entry_dn))
+            _dump_entry(output_dir, entry_dn, entry_data)
 
     @direct.command()
     @cli.admin.ON_EXCEPTIONS
-    @click.argument('rec_dn', required=True)
-    def delete(rec_dn):
-        """Delete LDAP object by DN"""
-        context.GLOBAL.ldap.conn.delete(rec_dn)
+    @click.argument('entry_dn', required=True)
+    def delete(entry_dn):
+        """Delete LDAP object by DN.
+        """
+        context.GLOBAL.admin.conn.delete(entry_dn)
 
     del get
+    del set_
     del delete
+    del list_
+    del dump
 
     return direct
+
+
+def _sorted_ldif_entry(entry_dn, entry_data):
+    """Generate a *sorted* version 1 LDIF entry.
+
+    The goal is that each entry's attribute is in alphabetical ordered.
+    Needed to have "stable" dumps, to be able to put them in version control.
+
+    :returns:
+        ``str`` - LDIFv1 representation of the entry.
+    """
+    # Make a sorted dictionary of key to list of utf8 encoded values
+    prepared_data = collections.OrderedDict(
+        [
+            (
+                key,
+                [
+                    datum.decode()
+                    for datum in entry_data[key]
+                ]
+            )
+            for key in sorted(entry_data.keys())
+        ]
+    )
+
+    output_stream = io.BytesIO()
+    writer = ldif3.LDIFWriter(output_stream, cols=78)
+    writer.unparse(
+        entry_dn, prepared_data
+    )
+
+    return output_stream.getvalue().decode()
+
+
+def _dump_entry(base, entry_dn, entry_data):
+    """Write an entry under a base directory.
+    """
+    subpath = ['data.ldif'] + entry_dn.split(',') + [base]
+    fullpath = os.path.join(*reversed(subpath))
+    fs.write_safe(
+        fullpath,
+        lambda fd: fd.write(_sorted_ldif_entry(entry_dn, entry_data)),
+        mode='w',
+        permission=0o644,
+    )

--- a/lib/python/treadmill/cli/admin/scheduler.py
+++ b/lib/python/treadmill/cli/admin/scheduler.py
@@ -136,7 +136,7 @@ def view_group(parent):
         if not full:
             output = output[[
                 'instance', 'allocation', 'partition', 'server',
-                'mem', 'cpu', 'disk'
+                'mem', 'cpu', 'disk', 'traits'
             ]]
 
         _print(output)

--- a/lib/python/treadmill/cli/run.py
+++ b/lib/python/treadmill/cli/run.py
@@ -33,6 +33,7 @@ def _run(apis,
          cpu,
          disk,
          tickets,
+         traits,
          service,
          restart_limit,
          restart_interval,
@@ -54,6 +55,9 @@ def _run(apis,
                             for name, port in endpoint]
     if tickets:
         app['tickets'] = tickets
+
+    if traits:
+        app['traits'] = traits
 
     if command:
         if not service:
@@ -143,6 +147,8 @@ def init():
                   callback=cli.validate_disk)
     @click.option('--tickets', help='Tickets.',
                   type=cli.LIST)
+    @click.option('--traits', help='Traits.',
+                  type=cli.LIST)
     @click.option('--service', help='Service name.', type=str)
     @click.option('--restart-limit', type=int, default=0,
                   help='Service restart limit.')
@@ -163,6 +169,7 @@ def init():
             cpu,
             disk,
             tickets,
+            traits,
             service,
             restart_limit,
             restart_interval,
@@ -181,7 +188,7 @@ def init():
         """
         apis = context.GLOBAL.cell_api()
         return _run(
-            apis, count, manifest, memory, cpu, disk, tickets,
+            apis, count, manifest, memory, cpu, disk, tickets, traits,
             service, restart_limit, restart_interval, endpoint,
             debug, debug_services, appname, command)
 

--- a/lib/python/treadmill/cli/scheduler/__init__.py
+++ b/lib/python/treadmill/cli/scheduler/__init__.py
@@ -41,8 +41,9 @@ def fetch_report(report_type, match=None, partition=None):
 def print_report(frame, explain=False):
     """Pretty-print the report."""
     if cli.OUTPUT_FORMAT is None:
-        frame.replace(True, ' ', inplace=True)
-        frame.replace(False, 'X', inplace=True)
+        if explain:
+            frame.replace(True, ' ', inplace=True)
+            frame.replace(False, 'X', inplace=True)
         dict_ = frame.to_dict(orient='split')
         del dict_['index']
         cli.out(

--- a/lib/python/treadmill/etc/schema/common.json
+++ b/lib/python/treadmill/etc/schema/common.json
@@ -76,6 +76,10 @@
         "maxLength": 128,
         "pattern": "^[a-zA-Z0-9-_]+=[a-zA-Z0-9\\-_\\.]+$"
     },
+    "app_user": {
+        "type": "string",
+        "pattern": "^([\\w\\-]+)@([\\w\\-]+)$"
+    },
     "app_id": {
         "anyOf": [
             {

--- a/lib/python/treadmill/exc.py
+++ b/lib/python/treadmill/exc.py
@@ -88,3 +88,9 @@ class QuotaExceededError(TreadmillError):
     """Thrown if quota is exceeded."""
 
     __slots__ = ()
+
+
+class InternalError(TreadmillError):
+    """Thrown on internal error that doesn't fall into any other category."""
+
+    __slots__ = ()

--- a/lib/python/treadmill/fs/__init__.py
+++ b/lib/python/treadmill/fs/__init__.py
@@ -76,7 +76,7 @@ def replace(path_from, path_to):
 
 
 def write_safe(filename, func, mode='wb', prefix='tmp', permission=None,
-               owner=None):
+               owner=None, subdir=None):
     """Safely write file.
 
     :param filename:
@@ -91,8 +91,13 @@ def write_safe(filename, func, mode='wb', prefix='tmp', permission=None,
         file permission
     :param owner
         file owner (uid, gui) tuple
+    :param subdir
+        create tempdir in subdir
     """
     dirname = os.path.dirname(filename)
+    if subdir:
+        dirname = os.path.join(dirname, subdir)
+
     try:
         os.makedirs(dirname)
     except OSError as err:

--- a/lib/python/treadmill/keytabs2.py
+++ b/lib/python/treadmill/keytabs2.py
@@ -1,0 +1,367 @@
+"""
+Handles keytab forwarding from keytab locker to the node. This is a upgraded
+version from `treadmill.keytab` which supports requesting by SPNs and relevant
+ownership.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import base64
+import glob
+import hashlib
+import io
+import logging
+import os
+import random
+import re
+import sqlite3
+
+from treadmill import discovery
+from treadmill import exc
+from treadmill import fs
+from treadmill import sysinfo
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# sqlite3 table name for tracking relationships between VIP keytab and proid
+_TABLE = 'keytab_proid_relations'
+
+
+class _KeytabLockerError(exc.TreadmillError):
+    """Treadmill keytab locker operation error.
+    """
+
+    __slots__ = ()
+
+
+def _write_keytab(fname, data):
+    """Safely writes data to file.
+
+    :param fname: Keytab filename.
+    :param data: Keytab data in bytes.
+    """
+    _LOGGER.info('Writing %s: %s', fname,
+                 hashlib.sha1(data).hexdigest())
+    fs.write_safe(
+        fname,
+        lambda f: f.write(data),
+        prefix='.tmp',
+        mode='wb'
+    )
+
+
+def _keytab2hostname(keytab):
+    """Parse hostname from keytab file name."""
+    res = re.match('^host#(.+)@(.*)$', keytab)
+    if res:
+        return res.group(1)
+    return None
+
+
+def ensure_table_exists(database):
+    """Creates table if table does not exist.
+
+    :param database: Path to SQLite3 db file.
+    """
+    conn = sqlite3.connect(database)
+    cur = conn.cursor()
+
+    # table columns definitions:
+    # proid: matched proid for the VIP keytab
+    # keytab: keytab file name e.g. host#vip1.domain.com@realm
+    cur.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS %s (proid text, keytab text)
+        ''' % _TABLE
+    )
+    conn.commit()
+    conn.close()
+
+
+class KeytabLocker:
+    """Manages keytab exchange.
+    """
+
+    def __init__(self, kt_spool_dir, database):
+        """KeytabLocker constructor.
+
+        :param kt_spool_dir: Path to store keytab files.
+        :param database: Path to SQLite3 db file which stores VIP keytab/proid
+                         relationships
+        """
+        self.kt_spool_dir = kt_spool_dir
+        self.database = database
+
+    def _get(self, vips):
+        """Get vip host keytabs"""
+        keytabs = dict()
+        try:
+            for kt_file in glob.glob(os.path.join(self.kt_spool_dir, '*')):
+                if kt_file.startswith('.tmp'):
+                    continue
+
+                vip = _keytab2hostname(kt_file)
+                if vip and vip in vips:
+                    with io.open(kt_file, 'rb') as f:
+                        keytabs[os.path.basename(kt_file)] = f.read()
+
+        except EnvironmentError:
+            _LOGGER.exception('Unhandled exception reading: %s',
+                              self.kt_spool_dir)
+
+        return keytabs
+
+    def _check_principal(self, princ):
+        """Validate keytab principal."""
+        if not princ or not princ.startswith('host/'):
+            raise _KeytabLockerError('expect host principal, got: %r' % princ)
+
+    def _check_vip_keytabs(self, proid, vips):
+        """Validate if proid matchs all required vip keytabs."""
+        conn = sqlite3.connect(self.database)
+        cur = conn.cursor()
+        sql = 'SELECT keytab FROM relations where proid = "%s"' % proid
+        saved = set(row[0] for row in cur.execute(sql))
+        conn.close()
+
+        expected = set(vips)
+        missed = expected - saved
+        _LOGGER.debug('Expected: %r', sorted(expected))
+        _LOGGER.debug('Actual  : %r', sorted(saved))
+
+        if missed:
+            raise _KeytabLockerError('miss vip keytabs: %r' % missed)
+
+    def get(self, princ, proid, vips):
+        """Process vip keytabs request."""
+        _LOGGER.info('Processing request %s, %s, %r', princ, proid, vips)
+
+        self._check_principal(princ)
+        self._check_vip_keytabs(proid, vips)
+
+        result = self._get(vips)
+        return result
+
+
+def get_listening_server(locker, port):
+    """Build keytab server protocol.
+    """
+    from treadmill.gssapiprotocol import jsonserver
+    from twisted.internet import protocol
+    from twisted.internet import reactor
+
+    def _response(success=False, message=None, keytabs=None):
+        """Construct response."""
+        return {
+            'success': success,
+            'message': message,
+            'keytabs': keytabs,
+        }
+
+    class _KeytabLockerServerProtocol(jsonserver.GSSAPIJsonServer):
+        """Implement keytab locker server protocol."""
+
+        def _get(self, req):
+            """Get keytabs for given host/app.
+            """
+            try:
+                keytabs = locker.get(self.peer(), req['proid'], req['vips'])
+            except KeyError:
+                raise _KeytabLockerError('Miss "proid" or "vips"')
+
+            _LOGGER.info('Sending keytabs for: %r', keytabs.keys())
+
+            # encode keytab binary data for json protocol compatibility
+            keytabs = {
+                ktname: base64.urlsafe_b64encode(binary)
+                for ktname, binary in keytabs.items()
+            }
+            return _response(success=True, keytabs=keytabs)
+
+        def _put(self, req):
+            """Store encoded keytab.
+            """
+            try:
+                keytab, encoded = req['keytab'], req['encoded']
+            except KeyError:
+                raise _KeytabLockerError('Miss "keytab" or "encoded"')
+
+            _LOGGER.info('put %s - %s',
+                         keytab,
+                         hashlib.sha1(encoded).hexdigest())
+
+            _write_keytab(
+                os.path.join(locker.kt_spool_dir, keytab),
+                encoded
+            )
+            return _response(success=True)
+
+        def on_request(self, request):
+            """Process keytab requests."""
+            action = request.get('action')
+            try:
+                if action == 'get':
+                    return self._get(request)
+                elif action == 'put':
+                    return self._put(request)
+                else:
+                    return _response(success=False, message='Unknown Action')
+
+            except _KeytabLockerError as err:
+                return _response(success=False, message=err.message)
+
+    class _KeytabLockerServer:
+        """Keytab locker server."""
+
+        def __init__(self):
+            """_KeytabLockerServer constructor."""
+            factory = protocol.Factory.forProtocol(_KeytabLockerServerProtocol)
+            listening_port = reactor.listenTCP(port, factory)
+
+            def _get_actual_port():
+                """Get actual listening port."""
+                return listening_port.getHost().port
+
+            def _run():
+                """Start keytab locker server"""
+                reactor.run()
+
+            self.get_actual_port = _get_actual_port
+            self.run = _run
+
+    return _KeytabLockerServer()
+
+
+def _get_keytabs_from(host, port, proid, vips, spool_dir):
+    """Get VIP keytabs from keytab locker server.
+    """
+    from treadmill.gssapiprotocol import jsonclient
+
+    service = 'host@%s' % host
+    _LOGGER.info('connecting: %s:%s, %s', host, port, service)
+    client = jsonclient.GSSAPIJsonClient(host, int(port), service)
+
+    try:
+        if not client.connect():
+            _LOGGER.warning(
+                'Cannot connect to %s:%s, %s', host, port, service
+            )
+            return False
+
+        _LOGGER.debug('connected to: %s:%s, %s', host, port, service)
+
+        request = {
+            'action': 'get',
+            'proid': proid,
+            'vips': vips,
+        }
+        client.write_json(request)
+
+        res = client.read_json()
+        if '_error' in res:
+            _LOGGER.warning('keytab locker internal err: %s', res['_error'])
+            return False
+
+        if not res['success']:
+            _LOGGER.warning('get keytab err: %s', res['message'])
+            return False
+
+        for ktname, encoded in res['keytabs'].items():
+            if encoded:
+                _LOGGER.info('got keytab %s:%r',
+                             ktname,
+                             hashlib.sha1(encoded).hexdigest())
+                keytab_data = base64.urlsafe_b64decode(encoded)
+                kt_file = os.path.join(spool_dir, ktname)
+                _write_keytab(kt_file, keytab_data)
+            else:
+                _LOGGER.warning('got empty keytab %s', ktname)
+                return False
+
+        return True
+
+    finally:
+        client.disconnect()
+
+
+def request_keytabs(zkclient, proid, vips, spool_dir):
+    """Request VIP keytabs from the keytab locker.
+
+    :param zkclient: Existing zk connection.
+    :param proid: Proid in container appname.
+    :param vips: VIP host list defined in manifest.
+    :param spool_dir: Path to keep keytabs fetched from keytab locker.
+    """
+    pattern = "{0}.keytabs-v2".format(os.environ['TREADMILL_ID'])
+    iterator = discovery.iterator(zkclient, pattern, 'keytabs', False)
+    hostports = []
+
+    for (_app, hostport) in iterator:
+        if not hostport:
+            continue
+        host, port = hostport.split(':')
+        hostports.append((host, int(port)))
+
+    random.shuffle(hostports)
+
+    for (host, port) in hostports:
+        fs.mkdir_safe(spool_dir)
+        if _get_keytabs_from(host, port, proid, vips, spool_dir):
+            return True
+
+    return False
+
+
+def sync_relations(spool_dir, database, query_proid_func):
+    """Sync VIP host keytab/proid relation if it does not exist.
+
+    :param spool_dir:
+        Path to keep keytabs fetched from keytab locker.
+    :param database:
+        Path to SQLite3 db file which stores VIP keytab/proid relationships.
+    :param query_proid_func:
+        Function object with signature `func(ktname: str) -> str`.
+    """
+    conn = sqlite3.connect(database)
+    cur = conn.cursor()
+    try:
+        keytab2proid = dict(
+            cur.execute('SELECT keytab, proid FROM %s ' % _TABLE)
+        )
+    except sqlite3.OperationalError as err:
+        # table may not exist yet, try sync in the next execution
+        _LOGGER.warning('wait for keytab locker starting.')
+        conn.close()
+        return
+
+    hostname = sysinfo.hostname()
+
+    missed = set()
+    for ktname in glob.glob(os.path.join(spool_dir, '*')):
+        ktname = os.path.basename(ktname)
+        # ignore local host keytab
+        if ktname not in keytab2proid and _keytab2hostname(ktname) != hostname:
+            missed.add(ktname)
+
+    _LOGGER.debug('keytabs without proid: %r', sorted(missed))
+
+    if missed:
+        values = []
+        for ktname in missed:
+            proid = query_proid_func(ktname)
+            _LOGGER.debug('keytab %s matches proid %s', ktname, proid)
+            values.append((ktname, proid))
+
+        cur.executemany(
+            """
+            INSERT INTO %s (keytab, proid) VALUES (?, ?)
+            """ % _TABLE,
+            values,
+        )
+        conn.commit()
+
+    conn.close()

--- a/lib/python/treadmill/reports.py
+++ b/lib/python/treadmill/reports.py
@@ -152,7 +152,7 @@ def allocations(cell, trait_codes):
     }).sort_values(by=['partition', 'name']).reset_index(drop=True)
 
 
-def apps(cell, _trait_codes):
+def apps(cell, trait_codes):
     """Prepare DataFrame with app and queue information."""
 
     # Hard-code order of columns
@@ -161,7 +161,7 @@ def apps(cell, _trait_codes):
         'identity_group', 'identity',
         'order', 'lease', 'expires', 'data_retention',
         'pending', 'server', 'util0', 'util1',
-        'mem', 'cpu', 'disk'
+        'mem', 'cpu', 'disk', 'traits'
     ]
 
     def _app_row(item):
@@ -182,6 +182,7 @@ def apps(cell, _trait_codes):
             'mem': app.demand[0],
             'cpu': app.demand[1],
             'disk': app.demand[2],
+            'traits': traits.format_traits(trait_codes, app.traits),
             'lease': app.lease,
             'expires': app.placement_expiry,
             'data_retention': app.data_retention_timeout,

--- a/lib/python/treadmill/rest/api/cell.py
+++ b/lib/python/treadmill/rest/api/cell.py
@@ -47,6 +47,7 @@ def init(api, cors, impl):
         'status': fields.String(description='Status'),
         'masters': fields.List(fields.Nested(master)),
         'partitions': fields.List(fields.Nested(partition)),
+        'traits': fields.List(fields.String(description='Traits')),
         'data': fields.Raw(),
     }
 

--- a/lib/python/treadmill/rest/api/instance.py
+++ b/lib/python/treadmill/rest/api/instance.py
@@ -175,9 +175,6 @@ def init(api, cors, impl):
             count = args.get('count', 1)
             debug = args.get('debug', False)
             debug_services = args.get('debug_services')
-            # FIXME: figure why action='split' doesn't split it.
-            if debug_services:
-                debug_services = debug_services.split(',')
 
             user = flask.g.get('user')
 

--- a/lib/python/treadmill/rest/limit.py
+++ b/lib/python/treadmill/rest/limit.py
@@ -5,23 +5,56 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import flask
+
 import flask_limiter
-import flask_limiter.util
+from flask_limiter import util
+
+
+def _get_key_func(limit_by=None):
+    """Get limit key factory function."""
+
+    def generate_limit_key():
+        """Generate key for request rate limiting."""
+        # use authenticated user if specified, otherwise use ip by default
+        if limit_by == 'user' and flask.g.get('user') is not None:
+            return flask.g.get('user')
+        return util.get_remote_address()
+
+    return generate_limit_key
 
 
 def wrap(app, rule):
     """Wrap flask app with rule based request rate control.
     """
+    limit_by = rule.pop('_limit_by', None)
     limiter = flask_limiter.Limiter(
         app,
-        key_func=flask_limiter.util.get_remote_address,
+        key_func=_get_key_func(limit_by=limit_by),
     )
 
     limit_value = rule.pop('_global', None)
     if limit_value is not None:
         decorator = limiter.shared_limit(limit_value, scope='_global')
         for endpoint, func in app.view_functions.items():
-            app.view_functions[endpoint] = decorator(func)
+            # A shared rate limit could be evaluated multiple times for single
+            # request, because `flask_limiter` uses
+            # "func.__module__ + func.__name__" as key format to differentiate
+            # non Blueprint routes.
+            #
+            # For example, both cases blow register to the same key format as
+            # "flask.helpers.send_static_file"
+            # 1. `restful_plus` static file requests (i.e. "/swaggerui/ui.js").
+            # 2. default static file endpoint registration of
+            # `treadmill.rest.FLASK_APP`, because param "static_folder" in
+            # constructer has its default value.
+            #
+            # so each request of hitting "flask.helpers.send_static_file" will
+            # increase rate limit counter by 2 (which 1 is expectation). A
+            # workaround here is only concerning about `treadmill.rest.api`
+            # resources.
+            if hasattr(func, 'view_class'):
+                app.view_functions[endpoint] = decorator(func)
 
     if rule:
         decorators = {

--- a/lib/python/treadmill/restclient.py
+++ b/lib/python/treadmill/restclient.py
@@ -90,6 +90,10 @@ class ValidationError(HttpExceptionWithResponse):
     """Error raised on HTTP 424 (Failed Dependency)."""
 
 
+class TooManyRequestsError(HttpExceptionWithResponse):
+    """Error raised on HTTP 429 (Over rate limit threshold)."""
+
+
 class NotFoundError(Exception):
     """Error raised on HTTP 404 (Not Found).
 
@@ -134,6 +138,7 @@ def _handle_error(url, response):
         http_client.CONFLICT: AlreadyExistsError(
             'Resource already exists: {}'.format(url)
         ),
+        http_client.TOO_MANY_REQUESTS: TooManyRequestsError(response),
         http_client.FAILED_DEPENDENCY: ValidationError(response),
         # XXX: Correct code is FORBIDDEN. Support invalid UNAUTHORIZED during
         #      migration.
@@ -356,5 +361,6 @@ CLI_REST_EXCEPTIONS = [
     (ValidationError, None),
     (NotAuthorizedError, handle_not_authorized),
     (BadRequestError, None),
+    (TooManyRequestsError, 'Exceed request limitation, Try again later.'),
     (MaxRequestRetriesError, None)
 ]

--- a/lib/python/treadmill/runtime/linux/_manifest.py
+++ b/lib/python/treadmill/runtime/linux/_manifest.py
@@ -78,7 +78,7 @@ def _get_docker_run_cmd(name, image,
 
     return tpl.format(
         name=name,
-        image=image,
+        image=shlex.quote(image),
         entrypoint=entrypoint,
         cmds=' '.join((shlex.quote(cmd) for cmd in commands))
     )

--- a/lib/python/treadmill/runtime/linux/_run.py
+++ b/lib/python/treadmill/runtime/linux/_run.py
@@ -111,7 +111,7 @@ def run(tm_env, runtime_config, container_dir, manifest):
     # NOTE: below here, MOUNT namespace is private
 
     # Unpack the image to the root directory.
-    img_impl.unpack(container_dir, root_dir, app, app_cgroups)
+    img_impl.unpack(container_dir, root_dir, app, app_cgroups, tm_env.data)
 
     # clean mounts.
     wanted_mounts = runtime_config.host_mount_whitelist

--- a/lib/python/treadmill/runtime/linux/image/_image_base.py
+++ b/lib/python/treadmill/runtime/linux/image/_image_base.py
@@ -17,23 +17,17 @@ class Image:
     """
 
     @abc.abstractmethod
-    def unpack(self, container_dir, root_dir, app, app_cgroups):
+    def unpack(self, container_dir, root_dir, app, app_cgroups, data):
         """Unpacks the image to the root dir.
 
-        :param container_dir:
+        :param ``str`` container_dir:
             The root path of the container.
-        :type container_dir:
-            ``str``
-        :param root_dir:
-            The root path to unpack the image
-        :type root_dir:
-            ``str``
-        :param app:
-            The application manifest
-        :type app:
-            ``dict``
-        :param app_cgroups:
-            The paths of app cgroups
-        :type app_cgroups:
-            ``dict``
+        :param ``str`` root_dir:
+            The root path to unpack the image.
+        :param ``dict`` app:
+            The application manifest.
+        :param ``dict`` app_cgroups:
+            The paths of app cgroups.
+        :param ``dict`` data:
+            Local configuration data.
         """

--- a/lib/python/treadmill/runtime/linux/image/tar.py
+++ b/lib/python/treadmill/runtime/linux/image/tar.py
@@ -74,14 +74,14 @@ class TarImage(_image_base.Image):
         self.tm_env = tm_env
         self.image_path = image_path
 
-    def unpack(self, container_dir, root_dir, app, app_cgroups):
+    def unpack(self, container_dir, root_dir, app, app_cgroups, data):
         _LOGGER.debug('Extracting tar file %r to %r.', self.image_path,
                       root_dir)
         with tarfile.open(self.image_path) as tar:
             tar.extractall(path=root_dir)
 
         native.NativeImage(self.tm_env).unpack(
-            container_dir, root_dir, app, app_cgroups
+            container_dir, root_dir, app, app_cgroups, data
         )
 
         # TODO: cache instead of removing TAR files.

--- a/lib/python/treadmill/scheduler/loader.py
+++ b/lib/python/treadmill/scheduler/loader.py
@@ -467,7 +467,9 @@ class Loader:
                                         schedule_once=schedule_once,
                                         data_retention_timeout=data_retention,
                                         traits=traits.encode(
-                                            self.trait_codes, traitz
+                                            self.trait_codes,
+                                            traitz,
+                                            use_invalid=True
                                         ),
                                         lease=lease)
 

--- a/lib/python/treadmill/services/_base_service.py
+++ b/lib/python/treadmill/services/_base_service.py
@@ -293,10 +293,8 @@ class ResourceService:
     _IO_EVENT_PENDING = struct.pack('@Q', 1)
 
     def __init__(self, service_dir, impl):
-        fs.mkdir_safe(service_dir)
         self._dir = os.path.realpath(service_dir)
         self._rsrc_dir = os.path.join(self._dir, RSRC_DIR)
-        fs.mkdir_safe(self._rsrc_dir)
         self._is_dead = False
         self._service_impl = impl
         self._service_class = None
@@ -580,6 +578,8 @@ class BaseResourceServiceImpl:
         """Service initialization."""
         self._service_dir = service_dir
         self._service_rsrc_dir = os.path.join(service_dir, RSRC_DIR)
+        fs.mkdir_safe(self._service_dir)
+        fs.mkdir_safe(self._service_rsrc_dir)
 
     @abc.abstractmethod
     def synchronize(self):

--- a/lib/python/treadmill/services/_linux_base_service.py
+++ b/lib/python/treadmill/services/_linux_base_service.py
@@ -105,11 +105,11 @@ class LinuxResourceService(_base_service.ResourceService):
     def _run(self, impl, watchdog_lease):
         """Linux implementation of run.
         """
-        # Create the status socket
-        ss = self._create_status_socket()
-
         # Run initialization
         impl.initialize(self._dir)
+
+        # Create the status socket
+        ss = self._create_status_socket()
 
         watcher = dirwatch.DirWatcher(self._rsrc_dir)
         # Call all the callbacks with the implementation instance

--- a/lib/python/treadmill/spawn/instance.py
+++ b/lib/python/treadmill/spawn/instance.py
@@ -55,7 +55,7 @@ class Instance:
 
             for doc in generator:
                 docs.append(doc)
-        except (IOError, yaml.YAMLError) as ex:
+        except (IOError, ValueError, yaml.YAMLError) as ex:
             _LOGGER.error(ex)
             return
 

--- a/lib/python/treadmill/sproc/alert_monitor.py
+++ b/lib/python/treadmill/sproc/alert_monitor.py
@@ -109,11 +109,15 @@ def _process_existing_alerts(alerts_dir, process_func):
         process_func(os.path.join(alerts_dir, alert_file))
 
 
-def _remove_extra_alerts(alerts_dir, max_queue_length):
+def _remove_extra_alerts(alerts_dir, max_queue_length=0):
     """Keep the most recent max_queue_length files in alerts_dir.
     """
-    for alert_file in sorted(os.listdir(alerts_dir))[:-1 * max_queue_length]:
-        fs.rm_safe(os.path.join(alerts_dir, alert_file))
+    # None means do not slice
+    index = None if max_queue_length == 0 else 0 - max_queue_length
+    for alert_file in sorted(os.listdir(alerts_dir))[:index]:
+        # if file/dir started as '.', we do not remove
+        if alert_file[0] != '.':
+            fs.rm_safe(os.path.join(alerts_dir, alert_file))
 
 
 def init():

--- a/lib/python/treadmill/sproc/appcfgmgr.py
+++ b/lib/python/treadmill/sproc/appcfgmgr.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import click
 
 from treadmill import appcfgmgr
+from treadmill import cli
 
 
 def init():
@@ -18,9 +19,10 @@ def init():
     @click.option('--approot', type=click.Path(exists=True),
                   envvar='TREADMILL_APPROOT', required=True)
     @click.option('--runtime', envvar='TREADMILL_RUNTIME', required=True)
-    def run(approot, runtime):
+    @click.option('--runtime-param', type=cli.LIST, required=False)
+    def run(approot, runtime, runtime_param=None):
         """Starts appcfgmgr process."""
-        mgr = appcfgmgr.AppCfgMgr(approot, runtime)
+        mgr = appcfgmgr.AppCfgMgr(approot, runtime, runtime_param)
         mgr.run()
 
     return run

--- a/lib/python/treadmill/sproc/keytabs.py
+++ b/lib/python/treadmill/sproc/keytabs.py
@@ -7,16 +7,66 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
+import os
+import time
+
 import click
 
-from treadmill import keytabs
+from treadmill import appenv
 from treadmill import context
+from treadmill import endpoints
+from treadmill import keytabs
+from treadmill import sysinfo
+from treadmill import zknamespace as z
+from treadmill import zkutils
 
 
 _LOGGER = logging.getLogger(__name__)
 
-# 24 hours.
-_KT_REFRESH_INTERVAL = 60 * 60 * 24
+
+def create_endpoint_file(approot, port, appname, endpoint):
+    """Create and link local endpoint file"""
+    hostport = '%s:%s' % (sysinfo.hostname(), port)
+    zkclinet = context.GLOBAL.zk.conn
+
+    endpoint_proid_path = z.path.endpoint_proid(appname)
+    acl = zkclinet.make_servers_acl()
+    _LOGGER.info(
+        'Ensuring %s exists with ACL %r',
+        endpoint_proid_path,
+        acl
+    )
+    zkutils.ensure_exists(
+        zkclinet,
+        endpoint_proid_path,
+        acl=[acl]
+    )
+
+    endpoint_path = z.path.endpoint(appname, 'tcp', endpoint)
+    _LOGGER.info('Registering %s %s', endpoint_path, hostport)
+
+    # Need to delete/create endpoints for the disovery to pick it up in
+    # case of master restart.
+    zkutils.ensure_deleted(zkclinet, endpoint_path)
+    time.sleep(5)
+    zkutils.put(zkclinet, endpoint_path, hostport)
+
+    tm_env = appenv.AppEnvironment(approot)
+    endpoints_mgr = endpoints.EndpointsMgr(tm_env.endpoints_dir)
+    endpoints_mgr.unlink_all(
+        appname=appname,
+        endpoint=endpoint,
+        proto='tcp'
+    )
+    endpoints_mgr.create_spec(
+        appname=appname,
+        endpoint=endpoint,
+        proto='tcp',
+        real_port=port,
+        pid=os.getpid(),
+        port=port,
+        owner='/proc/{}'.format(os.getpid()),
+    )
 
 
 def init():
@@ -30,10 +80,25 @@ def init():
     @top.command()
     @click.option('--kt-spool-dir',
                   help='Keytab spool directory.')
-    def locker(kt_spool_dir):
+    @click.option('--approot', type=click.Path(exists=True),
+                  envvar='TREADMILL_APPROOT', required=True)
+    @click.option('--port', help='Keytab locker server port.', default=0)
+    @click.option('--appname', help='Pseudo app name to use for discovery',
+                  required=True)
+    @click.option('--endpoint', help='Pseudo endpoint to use for discovery',
+                  default='keytabs')
+    def locker(kt_spool_dir, approot, port, appname, endpoint):
         """Run keytab locker daemon."""
         kt_locker = keytabs.KeytabLocker(context.GLOBAL.zk.conn, kt_spool_dir)
-        keytabs.run_server(kt_locker)
+        kt_server = keytabs.get_listening_server(kt_locker, port)
+
+        port = kt_server.get_actual_port()
+        kt_locker.register_endpoint(port)
+
+        create_endpoint_file(approot, port, appname, endpoint)
+
+        _LOGGER.info('Starting keytab locker server on port: %s', port)
+        kt_server.run()
 
     del locker
     return top

--- a/lib/python/treadmill/sproc/keytabs2.py
+++ b/lib/python/treadmill/sproc/keytabs2.py
@@ -1,0 +1,66 @@
+"""Runs Treadmill keytab locker service. This is a upgraded version from
+`treadmill.sproc.keytabs` which supports requesting by SPNs and relevant
+ownership.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+
+import click
+
+from treadmill import context
+from treadmill import keytabs2
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def init():
+    """Top level command handler."""
+
+    @click.group()
+    def top():
+        """Manage Kerberos keytabs.
+        """
+
+    @top.command()
+    @click.option('--kt-spool-dir',
+                  help='Keytab spool directory.')
+    @click.option('--approot',
+                  type=click.Path(exists=True),
+                  envvar='TREADMILL_APPROOT',
+                  required=True)
+    @click.option('--appname',
+                  help='Pseudo app name to use for discovery',
+                  required=True)
+    @click.option('--endpoint',
+                  help='Pseudo endpoint to use for discovery',
+                  default='keytabs-v2')
+    @click.option('-p', '--port',
+                  help='Keytab locker server port.',
+                  default=0)
+    @click.option('--database',
+                  required=True,
+                  type=click.Path(exists=True, readable=True),
+                  help='SQLite3 db file stores VIP keytab/proid relations.')
+    def locker(kt_spool_dir, approot, appname, endpoint, port, database):
+        """Run keytab locker daemon."""
+        kt_locker = keytabs2.KeytabLocker(context.GLOBAL.zk.conn, kt_spool_dir)
+        kt_server = keytabs2.get_listening_server(kt_locker, port)
+
+        # TODO: refator this as an untility function
+        from treadmill.sproc.keytabs import create_endpoint_file
+
+        port = kt_server.get_actual_port()
+        create_endpoint_file(approot, port, appname, endpoint)
+        keytabs2.ensure_table_exists(database)
+
+        _LOGGER.info('Starting keytab locker server on port: %s', port)
+        kt_server.run()
+
+    del locker
+    return top

--- a/lib/python/treadmill/sproc/tickets.py
+++ b/lib/python/treadmill/sproc/tickets.py
@@ -129,7 +129,7 @@ def init():
         # Need to delete/create endpoints for the disovery to pick it up in
         # case of master restart.
         #
-        # Unlile typical endpoint, we cannot make the node ephemeral as we
+        # Unlike typical endpoint, we cannot make the node ephemeral as we
         # exec into tkt-recv.
         zkutils.ensure_deleted(context.GLOBAL.zk.conn, endpoint_path)
         time.sleep(5)

--- a/lib/python/treadmill/subproc.py
+++ b/lib/python/treadmill/subproc.py
@@ -77,10 +77,12 @@ def _check(path):
     if path is None:
         return False
 
-    if path.endswith('.so') and (path.find('$ISA') >= 0 or
-                                 path.find('$LIB') >= 0):
-        # TODO: not sure how to handle $LIB and $ISA for now.
-        return True
+    if path.endswith('.so'):
+        if (path.find('$ISA') >= 0 or path.find('$LIB') >= 0):
+            # TODO: not sure how to handle $LIB and $ISA for now.
+            return True
+        else:
+            return os.access(path, os.R_OK)
     else:
         return os.access(path, os.X_OK)
 

--- a/lib/python/treadmill/tests/api/allocation_test.py
+++ b/lib/python/treadmill/tests/api/allocation_test.py
@@ -66,6 +66,17 @@ class ApiAllocationTest(unittest.TestCase):
              'memory': '1G'},
         )
 
+    # Disable W0212(protected-access)
+    # pylint: disable=W0212
+    @mock.patch('treadmill.api.allocation._api_plugins',
+                mock.Mock(return_value=[]))
+    def test_reservation_plugin_loading(self):
+        """Test loading of plugins"""
+        alloc_api = allocation.API(['test-plugin'])
+        treadmill.api.allocation._api_plugins.assert_called_once_with(
+            ['test-plugin']
+        )
+
     @mock.patch('treadmill.context.AdminContext.partition',
                 mock.Mock(return_value=mock.Mock(**{
                     'get.return_value': {

--- a/lib/python/treadmill/tests/api/instance_test.py
+++ b/lib/python/treadmill/tests/api/instance_test.py
@@ -447,6 +447,16 @@ class ApiInstanceTest(unittest.TestCase):
             ['sleep1', 'sleep2']
         )
 
+    @mock.patch('treadmill.context.ZkContext.conn', mock.Mock())
+    @mock.patch('treadmill.scheduler.masterapi.delete_apps')
+    def test_bulk_delete_pers_container(self, delete_apps_mock):
+        """Test bulk deleting personal container.
+        """
+        self.instance.bulk_delete('foo@bar', ['foo@bar.baz#123'])
+        delete_apps_mock.assert_called_once_with(
+            mock.ANY, ['foo@bar.baz#123'], None
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/python/treadmill/tests/api/schema_test.py
+++ b/lib/python/treadmill/tests/api/schema_test.py
@@ -202,12 +202,6 @@ class ApiSchemaTest(unittest.TestCase):
         # FIXME(boysson) _fail(api.create, 'foo.bla',
         #                      _patch(good, '/passthrough/0', '@.example.com'))
 
-        # archive
-        good.update({'archive': ['/var/tmp', 'xxx/*.log']})
-        _ok(api.create, 'foo.bla', good)
-        _fail(api.create, 'foo.bla', _patch(good, '/archive/0', 1))
-        _fail(api.create, 'foo.bla', _patch(good, '/archive', 'aaa'))
-
         # vring.
         good.update({'vring': {
             'cells': ['aaa-001', 'bbb-001'],

--- a/lib/python/treadmill/tests/appcfg/docker_feature_test.py
+++ b/lib/python/treadmill/tests/appcfg/docker_feature_test.py
@@ -13,20 +13,154 @@ import mock
 import treadmill.tests.treadmill_test_skip_windows  # pylint: disable=W0611
 
 from treadmill.appcfg import features
+from treadmill.appcfg.features import docker as docker_feature
 
 
 class AppCfgDockerFeatureTest(unittest.TestCase):
     """Test for docker feature
     """
 
+    @mock.patch('treadmill.nodedata.get', specs_set=True)
+    def test__get_tls_conf(self, mock_nodedata_get):
+        """Test getting list of registries
+        """
+        # pylint: disable=protected-access
+
+        mock_nodedata_get.return_value = {
+            'tls_certs': {
+                'ca_cert': 'foo',
+                'host_cert': 'bar',
+                'host_key': 'baz',
+            }
+        }
+        mock_env = mock.Mock()
+
+        res = docker_feature._get_tls_conf(mock_env)
+
+        self.assertEqual(
+            res,
+            {
+                'ca_cert': 'foo',
+                'host_cert': 'bar',
+                'host_key': 'baz',
+            }
+        )
+
+        mock_nodedata_get.return_value = {
+            'tls_certs': {}
+        }
+
+        res = docker_feature._get_tls_conf(mock_env)
+
+        self.assertEqual(
+            res,
+            {
+                'ca_cert': '',
+                'host_cert': '',
+                'host_key': '',
+            }
+        )
+
+    @mock.patch('treadmill.appcfg.features.docker.socket.getfqdn',
+                specs_set=True)
+    @mock.patch('treadmill.nodedata.get', specs_set=True)
+    def test__get_docker_registry(self, mock_nodedata_get, mock_fqdn):
+        """Test getting list of registries
+        """
+        # pylint: disable=protected-access
+
+        mock_nodedata_get.return_value = {
+            'docker_registries': {
+                'dev': ['foo', 'bar:1234'],
+                'prod': ['mshub.ms.com'],
+            }
+        }
+        mock_fqdn.side_effect = [
+            'somehost1',
+            'somehost2',
+            'somehost3',
+        ]
+        mock_env = mock.Mock()
+
+        dev_res = docker_feature._get_docker_registry(mock_env, 'dev')
+        self.assertEqual(
+            list(dev_res),
+            [
+                'somehost1',
+                'somehost2:1234'
+            ]
+        )
+        mock_fqdn.assert_has_calls([
+            mock.call('foo'),
+            mock.call('bar'),
+        ])
+        mock_fqdn.reset_mock()
+
+        prod_res = docker_feature._get_docker_registry(mock_env, 'prod')
+        self.assertEqual(
+            list(prod_res),
+            [
+                'somehost3',
+            ]
+        )
+        mock_fqdn.assert_has_calls([
+            mock.call('mshub.ms.com'),
+        ])
+        mock_fqdn.reset_mock()
+
+        foo_res = docker_feature._get_docker_registry(mock_env, 'foo')
+        self.assertEqual(
+            list(foo_res),
+            []
+        )
+        mock_fqdn.assert_has_calls([])
+
+        # Compatibitily mode test
+        mock_nodedata_get.return_value = {
+            'docker_registries': ['foo', 'bar:1234'],
+        }
+        mock_fqdn.side_effect = [
+            'somehost1',
+            'somehost2',
+        ]
+
+        dev_res = docker_feature._get_docker_registry(mock_env, 'dev')
+        self.assertEqual(
+            list(dev_res),
+            [
+                'somehost1',
+                'somehost2:1234'
+            ]
+        )
+
+        mock_fqdn.side_effect = [
+            'somehost1',
+            'somehost2',
+        ]
+        prod_res = docker_feature._get_docker_registry(mock_env, 'prod')
+        self.assertEqual(
+            list(prod_res),
+            [
+                'somehost1',
+                'somehost2:1234'
+            ]
+        )
+
     @mock.patch('treadmill.subproc.resolve', mock.Mock(return_value='tm'))
     @mock.patch('treadmill.utils.get_ulimit', mock.Mock(return_value=(0, 0)))
+    @mock.patch('treadmill.appcfg.features.docker._get_tls_conf',
+                mock.Mock(return_value=dict(
+                    ca_cert='/ca.pem',
+                    host_cert='/host.pem',
+                    host_key='/host.key'
+                )))
     @mock.patch('treadmill.appcfg.features.docker._get_docker_registry',
                 mock.Mock(return_value=iter(['foo:5050', 'bar:5050'])))
     def test_docker_feature(self):
         """test apply dockerd feature
         """
         manifest = {
+            'environment': 'dev',
             'services': [],
             'system_services': [],
             'features': ['docker'],
@@ -50,22 +184,28 @@ class AppCfgDockerFeatureTest(unittest.TestCase):
         self.assertTrue(manifest['services'][0]['root'])
         self.assertEqual(
             manifest['services'][0]['command'],
-            ('exec tm'
-             ' -H tcp://127.0.0.1:2375'
-             ' --authorization-plugin=authz'
-             ' --add-runtime docker-runc=tm --default-runtime=docker-runc'
-             ' --exec-opt native.cgroupdriver=cgroupfs --bridge=none'
-             ' --ip-forward=false --ip-masq=false --iptables=false'
-             ' --cgroup-parent=docker --block-registry="*"'
-             ' --default-ulimit core=0:0'
-             ' --default-ulimit data=0:0'
-             ' --default-ulimit fsize=0:0'
-             ' --default-ulimit nproc=0:0'
-             ' --default-ulimit nofile=0:0'
-             ' --default-ulimit rss=0:0'
-             ' --default-ulimit stack=0:0'
-             ' --insecure-registry foo:5050 --add-registry foo:5050'
-             ' --insecure-registry bar:5050 --add-registry bar:5050')
+            (
+                'exec tm'
+                ' -H tcp://127.0.0.1:2375'
+                ' --authorization-plugin=authz'
+                ' --add-runtime docker-runc=tm --default-runtime=docker-runc'
+                ' --exec-opt native.cgroupdriver=cgroupfs --bridge=none'
+                ' --ip-forward=false --ip-masq=false --iptables=false'
+                ' --cgroup-parent=docker --block-registry="*"'
+                ' --default-ulimit core=0:0'
+                ' --default-ulimit data=0:0'
+                ' --default-ulimit fsize=0:0'
+                ' --default-ulimit nproc=0:0'
+                ' --default-ulimit nofile=0:0'
+                ' --default-ulimit rss=0:0'
+                ' --default-ulimit stack=0:0'
+                ' --tlsverify'
+                ' --tlscacert=/ca.pem'
+                ' --tlscert=/host.pem'
+                ' --tlskey=/host.key'
+                ' --add-registry foo:5050'
+                ' --add-registry bar:5050'
+            )
         )
         self.assertEqual(manifest['services'][1]['name'], 'docker-auth')
         self.assertTrue(manifest['services'][1]['root'])

--- a/lib/python/treadmill/tests/appcfgmgr_test.py
+++ b/lib/python/treadmill/tests/appcfgmgr_test.py
@@ -62,7 +62,8 @@ class AppCfgMgrTest(unittest.TestCase):
         treadmill.appcfg.configure.configure.assert_called_with(
             self.appcfgmgr.tm_env,
             os.path.join(self.cache, 'foo#1'),
-            'linux'
+            'linux',
+            None
         )
         treadmill.fs.symlink_safe.assert_called_with(
             os.path.join(self.running, 'foo#1'),

--- a/lib/python/treadmill/tests/cellsync_test.py
+++ b/lib/python/treadmill/tests/cellsync_test.py
@@ -50,7 +50,7 @@ class CellsyncTest(unittest.TestCase):
         ], any_order=True)
         zkclient.create.assert_called_once_with(
             '/app-groups/test.foo',
-            b'cells: [test]\n',
+            b'{"cells": ["test"]}',
             makepath=True, ephemeral=False, acl=mock.ANY, sequence=False
         )
 

--- a/lib/python/treadmill/tests/cleanup_test.py
+++ b/lib/python/treadmill/tests/cleanup_test.py
@@ -68,7 +68,7 @@ class CleanupTest(unittest.TestCase):
             )
         )
 
-    @mock.patch('os.path.islink', mock.Mock())
+    @mock.patch('treadmill.cleanup._islink', mock.Mock())
     @mock.patch('treadmill.supervisor.create_service', mock.Mock())
     @mock.patch('treadmill.fs.symlink_safe', mock.Mock())
     @mock.patch('treadmill.cleanup.Cleanup._refresh_supervisor', mock.Mock())
@@ -79,7 +79,7 @@ class CleanupTest(unittest.TestCase):
         """
         # Access to a protected member _add_cleanup_app of a client class
         # pylint: disable=W0212
-        os.path.islink.side_effect = [False, True]
+        treadmill.cleanup._islink.side_effect = [False, True]
 
         self.cleanup._add_cleanup_app(
             os.path.join(self.cleanup_dir, 'proid.app#0000000000001'))
@@ -109,14 +109,14 @@ class CleanupTest(unittest.TestCase):
 
         treadmill.cleanup.Cleanup._refresh_supervisor.assert_called()
 
-    @mock.patch('os.path.islink', mock.Mock())
+    @mock.patch('treadmill.cleanup._islink', mock.Mock())
     @mock.patch('treadmill.supervisor.create_service', mock.Mock())
     def test__add_cleanup_app_exists(self):
         """Tests add app when already exists.
         """
         # Access to a protected member _add_cleanup_app of a client class
         # pylint: disable=W0212
-        os.path.islink.side_effect = [True]
+        treadmill.cleanup._islink.side_effect = [True]
 
         self.cleanup._add_cleanup_app(
             os.path.join(self.cleanup_dir, 'proid.app#0000000000001'))
@@ -125,14 +125,14 @@ class CleanupTest(unittest.TestCase):
 
     # Disable C0103(Invalid method name)
     # pylint: disable=C0103
-    @mock.patch('os.path.islink', mock.Mock())
+    @mock.patch('treadmill.cleanup._islink', mock.Mock())
     @mock.patch('treadmill.supervisor.create_service', mock.Mock())
     def test__add_cleanup_app_not_exists(self):
         """Tests add app when cleanup link does not exist.
         """
         # Access to a protected member _add_cleanup_app of a client class
         # pylint: disable=W0212
-        os.path.islink.side_effect = [False, False]
+        treadmill.cleanup._islink.side_effect = [False, False]
 
         self.cleanup._add_cleanup_app(
             os.path.join(self.cleanup_dir, 'proid.app#0000000000001'))

--- a/lib/python/treadmill/tests/cli/admin/blackout_test.py
+++ b/lib/python/treadmill/tests/cli/admin/blackout_test.py
@@ -33,7 +33,7 @@ class AdminBlackoutTest(unittest.TestCase):
     def test_list_app_blackouts(self):
         """Test listing app blackouts."""
         context.GLOBAL.zk.conn.get.return_value = (
-            """
+            b"""
                 foo.*: {reason: test, when: 1234567890.0}
                 bar.baz: {reason: test, when: 1234567890.0}
             """,
@@ -67,7 +67,7 @@ class AdminBlackoutTest(unittest.TestCase):
     def test_blackout_app(self):
         """Test app blackout."""
         context.GLOBAL.zk.conn.get.return_value = (
-            """
+            b"""
                 foo.*: {reason: test, when: 1234567890.0}
             """,
             mock.Mock()
@@ -128,7 +128,7 @@ class AdminBlackoutTest(unittest.TestCase):
     def test_clear_app_blackout(self):
         """Test clearing app blackout."""
         context.GLOBAL.zk.conn.get.return_value = (
-            """
+            b"""
                 foo.*: {reason: test, when: 1234567890.0}
                 bar.baz: {reason: test, when: 1234567890.0}
             """,

--- a/lib/python/treadmill/tests/context_test.py
+++ b/lib/python/treadmill/tests/context_test.py
@@ -157,6 +157,33 @@ class ContextTest(unittest.TestCase):
             mock.call('_http._tcp.adminapi.na.region.a.com', mock.ANY),
         ])
 
+    @mock.patch('treadmill.dnsutils.srv', mock.Mock(return_value=[]))
+    @mock.patch.dict(
+        'os.environ', {
+            'TREADMILL_ADMINAPI_LOOKUP_GLOBAL': '_http._tcp.foo.admin',
+            'TREADMILL_CELLAPI_LOOKUP_Y': '_http._tcp.foo.cell',
+            'TREADMILL_WSAPI_LOOKUP_Y': '_http._tcp.foo.ws',
+            'TREADMILL_STATEAPI_LOOKUP_Y': '_http._tcp.foo.state',
+        }
+    )
+    def test_api_resolve_override(self):
+        """Test DNS resolution of the api with override."""
+        ctx = context.Context()
+        ctx.dns_domain = 'a.com'
+        ctx.cell = 'y'
+        treadmill.dnsutils.srv.return_value = [('xxx', 123, 1, 2),
+                                               ('yyy', 234, 3, 4)]
+        ctx.admin_api()
+        ctx.cell_api()
+        ctx.ws_api()
+        ctx.state_api()
+        treadmill.dnsutils.srv.assert_has_calls([
+            mock.call('_http._tcp.foo.admin.a.com', mock.ANY),
+            mock.call('_http._tcp.foo.cell.a.com', mock.ANY),
+            mock.call('_http._tcp.foo.ws.a.com', mock.ANY),
+            mock.call('_http._tcp.foo.state.a.com', mock.ANY),
+        ])
+
     @mock.patch.dict(
         'os.environ', {
             'TREADMILL_ADMINAPI': 'http://x:123',

--- a/lib/python/treadmill/tests/eventmgr_test.py
+++ b/lib/python/treadmill/tests/eventmgr_test.py
@@ -81,7 +81,7 @@ class EventMgrTest(mockzk.MockZookeeperTestCase):
             side_effect=lambda func: func({'valid_until': 123.0}, None, None)
         )
 
-        mock_zkclient.get.return_value = ('{}', mock.Mock(ctime=1000))
+        mock_zkclient.get.return_value = (b'{}', mock.Mock(ctime=1000))
         mock_zkclient.exits.return_value = mock.Mock()
         # Decorator style watch
         mock_zkclient.DataWatch.return_value = mock_data_watch
@@ -120,7 +120,7 @@ class EventMgrTest(mockzk.MockZookeeperTestCase):
             side_effect=lambda func: func(None, None, None)
         )
 
-        mock_zkclient.get.return_value = ('{}', mock.Mock(ctime=1000))
+        mock_zkclient.get.return_value = (b'{}', mock.Mock(ctime=1000))
         mock_zkclient.exits.return_value = mock.Mock()
         # Decorator style watch
         mock_zkclient.DataWatch.return_value = mock_data_watch

--- a/lib/python/treadmill/tests/fs_test.py
+++ b/lib/python/treadmill/tests/fs_test.py
@@ -752,7 +752,8 @@ class FsTest(unittest.TestCase):
         )
 
     def test_write_safe(self):
-        """Tests write safe."""
+        """Tests write_safe.
+        """
         tmpdir = tempfile.mkdtemp()
         treadmill.fs.write_safe(
             os.path.join(tmpdir, 'xxx'), lambda f: f.write(b'foo')
@@ -760,6 +761,24 @@ class FsTest(unittest.TestCase):
         with io.open(os.path.join(tmpdir, 'xxx'), 'rb') as f:
             self.assertEqual(b'foo', f.read())
         self.assertEqual(['xxx'], os.listdir(tmpdir))
+        os.unlink(os.path.join(tmpdir, 'xxx'))
+        # Cleanup.
+        shutil.rmtree(tmpdir)
+
+    def test_write_safe_subdir(self):
+        """Tests write_safe with subdir
+        """
+        tmpdir = tempfile.mkdtemp()
+        treadmill.fs.write_safe(
+            os.path.join(tmpdir, 'xxx'),
+            lambda f: f.write(f.name.encode()),
+            subdir='.tmp'
+        )
+
+        with io.open(os.path.join(tmpdir, 'xxx'), 'rb') as f:
+            self.assertTrue(os.path.join(tmpdir, '.tmp') in f.read().decode())
+
+        self.assertEqual(set(['xxx', '.tmp']), set(os.listdir(tmpdir)))
         os.unlink(os.path.join(tmpdir, 'xxx'))
         # Cleanup.
         shutil.rmtree(tmpdir)

--- a/lib/python/treadmill/tests/keytabs2_test.py
+++ b/lib/python/treadmill/tests/keytabs2_test.py
@@ -1,0 +1,125 @@
+"""Unit test for keytabs2
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import base64
+import os
+import sqlite3
+import shutil
+import tempfile
+import unittest
+
+import mock
+
+# Disable W0611: Unused import
+import treadmill.tests.treadmill_test_skip_windows  # pylint: disable=W0611
+
+from treadmill import fs
+from treadmill import keytabs2
+
+
+class Keytabs2Test(unittest.TestCase):
+    """Tests for module teadmill.keytabs2"""
+
+    def setUp(self):
+        self.spool_dir = tempfile.mkdtemp()
+        self.sqlite3_dir = tempfile.mkdtemp()
+        self.database = os.path.join(self.sqlite3_dir, 'test.db')
+
+    def tearDown(self):
+        shutil.rmtree(self.spool_dir)
+
+    @mock.patch('kazoo.client.KazooClient')
+    @mock.patch('treadmill.discovery.iterator')
+    @mock.patch('treadmill.gssapiprotocol.jsonclient.GSSAPIJsonClient')
+    @mock.patch('treadmill.keytabs2._write_keytab')
+    def test_request_keytabs(self, mock_write_keytab, mock_client_class,
+                             mock_iterator, mock_zkclient):
+        """Test request_keytabs"""
+        os.environ['TREADMILL_ID'] = 'treadmill'
+        proid = 'proida'
+        vips = ['host1.com', 'host2.com']
+        spool_dir = self.spool_dir
+
+        mock_iterator.return_value = [('foo:tcp:keytabs', '127.0.0.1:12345')]
+        mock_json_client = mock.Mock()
+        mock_client_class.return_value = mock_json_client
+
+        # test connection error
+        mock_json_client.connect.return_value = False
+        self.assertFalse(
+            keytabs2.request_keytabs(mock_zkclient, proid, vips, spool_dir)
+        )
+        mock_json_client.connect.assert_called_once()
+
+        # test server internal error
+        mock_json_client.reset_mock()
+        mock_json_client.connect.return_value = True
+        mock_json_client.read_json.return_value = {
+            'success': False,
+            'message': 'ops..',
+        }
+        self.assertFalse(
+            keytabs2.request_keytabs(mock_zkclient, proid, vips, spool_dir)
+        )
+        mock_json_client.write_json.assert_called_once_with(
+            {
+                'action': 'get',
+                'proid': proid,
+                'vips': vips,
+            }
+        )
+
+        # test valid keytabs with arbitrary bytes
+        keytab_1 = os.urandom(10)
+        keytab_2 = os.urandom(10)
+        mock_json_client.read_json.return_value = {
+            'success': True,
+            'keytabs': {
+                'ktname_1': base64.b64encode(keytab_1),
+                'ktname_2': base64.b64encode(keytab_2),
+            },
+        }
+        self.assertTrue(
+            keytabs2.request_keytabs(mock_zkclient, proid, vips, spool_dir)
+        )
+        mock_write_keytab.assert_has_calls(
+            [
+                mock.call(os.path.join(self.spool_dir, 'ktname_1'), keytab_1),
+                mock.call(os.path.join(self.spool_dir, 'ktname_2'), keytab_2),
+            ],
+            any_order=True,
+        )
+
+    def test_sync_relations(self):
+        """Test sync_relations"""
+        fs.mkfile_safe(os.path.join(self.spool_dir, 'princ#vip1.com@realm'))
+        fs.mkfile_safe(os.path.join(self.spool_dir, 'princ#vip2.com@realm'))
+
+        data = {
+            'princ#vip1.com@realm': 'proid1',
+            'princ#vip2.com@realm': 'proid2',
+        }
+
+        def find_proid(ktname):
+            """Peuso proid lookup func"""
+            return data[ktname]
+
+        keytabs2.ensure_table_exists(self.database)
+        keytabs2.sync_relations(self.spool_dir, self.database, find_proid)
+
+        conn = sqlite3.connect(self.database)
+        cur = conn.cursor()
+        rows = cur.execute('SELECT keytab, proid FROM keytab_proid_relations')
+        try:
+            self.assertEqual(data, dict(rows))
+        finally:
+            conn.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/python/treadmill/tests/master_test.py
+++ b/lib/python/treadmill/tests/master_test.py
@@ -241,7 +241,7 @@ class MasterTest(mockzk.MockZookeeperTestCase):
     @mock.patch('kazoo.client.KazooClient.get', mock.Mock())
     def test_load_allocations(self):
         """Tests loading allocation from serialized db data."""
-        kazoo.client.KazooClient.get.return_value = ("""
+        kazoo.client.KazooClient.get.return_value = (b"""
 ---
 - name: treadmill/dev
   assignments:
@@ -1452,7 +1452,7 @@ class MasterTest(mockzk.MockZookeeperTestCase):
         kazoo.client.KazooClient.create.assert_has_calls([
             mock.call(
                 '/scheduled/foo.bar#',
-                value=b'{}\n',
+                value=b'{}',
                 makepath=True,
                 sequence=True,
                 ephemeral=False,
@@ -1467,7 +1467,7 @@ class MasterTest(mockzk.MockZookeeperTestCase):
             # Mock call returns same instance (#12), so same task is created
             # twice.
             mock.call('/scheduled/foo.bar#',
-                      value=b'{}\n',
+                      value=b'{}',
                       makepath=True,
                       sequence=True,
                       ephemeral=False,
@@ -1482,7 +1482,7 @@ class MasterTest(mockzk.MockZookeeperTestCase):
         masterapi.create_apps(zkclient, 'foo.bar', {}, 1, 'monitor')
         kazoo.client.KazooClient.create.assert_has_calls([
             mock.call('/scheduled/foo.bar#',
-                      value=b'{}\n',
+                      value=b'{}',
                       makepath=True,
                       sequence=True,
                       ephemeral=False,
@@ -1544,7 +1544,7 @@ class MasterTest(mockzk.MockZookeeperTestCase):
         ])
 
     @mock.patch('kazoo.client.KazooClient.get', mock.Mock(
-        return_value=('{}', None)))
+        return_value=(b'{}', None)))
     @mock.patch('kazoo.client.KazooClient.set', mock.Mock())
     @mock.patch('kazoo.client.KazooClient.create', mock.Mock())
     def test_update_app_priority(self):
@@ -1556,8 +1556,8 @@ class MasterTest(mockzk.MockZookeeperTestCase):
                                                    'foo.bar#2': 20})
         kazoo.client.KazooClient.set.assert_has_calls(
             [
-                mock.call('/scheduled/foo.bar#1', b'{priority: 10}\n'),
-                mock.call('/scheduled/foo.bar#2', b'{priority: 20}\n'),
+                mock.call('/scheduled/foo.bar#1', b'{"priority": 10}'),
+                mock.call('/scheduled/foo.bar#2', b'{"priority": 20}'),
             ],
             any_order=True
         )
@@ -1569,7 +1569,7 @@ class MasterTest(mockzk.MockZookeeperTestCase):
         )
 
     @mock.patch('kazoo.client.KazooClient.get', mock.Mock(
-        return_value=('{}', None)))
+        return_value=(b'{}', None)))
     @mock.patch('treadmill.zkutils.update', mock.Mock(return_value=None))
     @mock.patch('treadmill.scheduler.masterapi.create_event',
                 mock.Mock(return_value=None))
@@ -1594,7 +1594,7 @@ class MasterTest(mockzk.MockZookeeperTestCase):
         self.assertFalse(treadmill.scheduler.masterapi.create_event.called)
 
     @mock.patch('kazoo.client.KazooClient.get', mock.Mock(
-        return_value=('{}', None)))
+        return_value=(b'{}', None)))
     @mock.patch('kazoo.client.KazooClient.set', mock.Mock())
     @mock.patch('kazoo.client.KazooClient.create', mock.Mock())
     @mock.patch('kazoo.client.KazooClient.exists',
@@ -1831,7 +1831,7 @@ class MasterTest(mockzk.MockZookeeperTestCase):
         )
 
     @mock.patch('kazoo.client.KazooClient.get', mock.Mock(
-        return_value=('{}', None)))
+        return_value=(b'{}', None)))
     @mock.patch('kazoo.client.KazooClient.set', mock.Mock())
     @mock.patch('kazoo.client.KazooClient.create', mock.Mock())
     def test_update_server_features(self):
@@ -1843,7 +1843,7 @@ class MasterTest(mockzk.MockZookeeperTestCase):
 
         kazoo.client.KazooClient.set.assert_has_calls(
             [
-                mock.call('/servers/foo.ms.com', b'features: [test]\n'),
+                mock.call('/servers/foo.ms.com', b'{"features": ["test"]}'),
             ],
             any_order=True
         )

--- a/lib/python/treadmill/tests/presence_test.py
+++ b/lib/python/treadmill/tests/presence_test.py
@@ -177,7 +177,7 @@ class PresenceTest(mockzk.MockZookeeperTestCase):
 
         kazoo.client.KazooClient.create.reset()
         kazoo.client.KazooClient.create.side_effect = node_exists
-        kazoo.client.KazooClient.get.return_value = ('{}', {})
+        kazoo.client.KazooClient.get.return_value = (b'{}', {})
         app_presence.register_endpoints()
         self.assertTrue(retry_happened)
         self.assertTrue(time.sleep.called)
@@ -327,11 +327,11 @@ class PresenceTest(mockzk.MockZookeeperTestCase):
         )
         zkclient_mock.set.assert_called_once_with(
             '/servers/xxx.xx.com',
-            b"{parent: 'rack:test123', up_since: '123.45'}\n"
+            b'{"parent": "rack:test123", "up_since": "123.45"}'
         )
         zkclient_mock.create.assert_called_once_with(
             '/server.presence/xxx.xx.com#',
-            b'{seen: false}\n',
+            b'{"seen": false}',
             acl=mock.ANY, ephemeral=True, makepath=True, sequence=True
         )
 

--- a/lib/python/treadmill/tests/reports_test.py
+++ b/lib/python/treadmill/tests/reports_test.py
@@ -143,23 +143,23 @@ class ReportsTest(unittest.TestCase):
             [
                 'bla.xxx#3', 't2/a1', 100, 'bla.xxx', 'part',
                 None, -1, 3, 0, 100,
-                0, 0, 'srv1', -0.142857142857, -0.128571, 1, 1, 1
+                0, 0, 'srv1', -0.142857142857, -0.128571, 1, 1, 1, ''
             ],
             [
                 'foo.xxx#1', 't1/t3/a2', 100, 'foo.xxx', '_default',
                 None, -1, 1, 0, 100,
-                0, 0, 'srv3', -0.142857142857, -0.128571, 1, 1, 1
+                0, 0, 'srv3', -0.142857142857, -0.128571, 1, 1, 1, ''
             ],
             [
                 'foo.xxx#2', 't1/t3/a2', 100, 'foo.xxx', '_default',
                 None, -1, 2, 0, 100,
-                0, 0, 'srv4', -0.128571428571, -0.114286, 1, 1, 1
+                0, 0, 'srv4', -0.128571428571, -0.114286, 1, 1, 1, ''
             ],
         ], columns=[
             'instance', 'allocation', 'rank', 'affinity', 'partition',
             'identity_group', 'identity', 'order', 'lease', 'expires',
             'data_retention', 'pending', 'server', 'util0', 'util1',
-            'mem', 'cpu', 'disk'
+            'mem', 'cpu', 'disk', 'traits'
         ]).sort_values(by=['partition',
                            'rank',
                            'util0',
@@ -223,7 +223,7 @@ class ReportsTest(unittest.TestCase):
             'identity_group', 'identity',
             'order', 'lease', 'expires', 'data_retention',
             'pending', 'server', 'util0', 'util1',
-            'mem', 'cpu', 'disk'
+            'mem', 'cpu', 'disk', 'traits'
         ]).astype({
             'mem': 'int',
             'cpu': 'int',

--- a/lib/python/treadmill/tests/rest/api/instance_test.py
+++ b/lib/python/treadmill/tests/rest/api/instance_test.py
@@ -42,7 +42,6 @@ class InstanceTest(unittest.TestCase):
         instance.init(api, cors, self.impl)
         self.client = self.app.test_client()
 
-    @unittest.skip('BROKEN: Flask exception handling')  # FIXME
     def test_post_instance(self):
         """Test creating an instance."""
         self.impl.create.return_value = ['proid.app#0000000001']

--- a/lib/python/treadmill/tests/rest/api/local_test.py
+++ b/lib/python/treadmill/tests/rest/api/local_test.py
@@ -130,7 +130,6 @@ class LocalTest(unittest.TestCase):
         )
         self.assertTrue(self.impl.log.get_all.called)
 
-    @unittest.skip('BROKEN: Flask exception handling')  # FIXME
     def test_app_log_failure(self):
         """Dummy tests for the case when logs cannot be found."""
         self.impl.log.get.side_effect = LocalFileNotFoundError('foo')
@@ -151,7 +150,6 @@ class LocalTest(unittest.TestCase):
         resp = self.client.get('/archive/<app>/<uniq>/app')
         self.assertEqual(resp.status_code, http_client.OK)
 
-    @unittest.skip('BROKEN: Flask exception handling')  # FIXME
     def test_arch_get_err(self):
         """Dummy tests for returning application archives (not found)
         """

--- a/lib/python/treadmill/tests/rest/api/state_test.py
+++ b/lib/python/treadmill/tests/rest/api/state_test.py
@@ -90,7 +90,6 @@ class StateTest(unittest.TestCase):
         self.assertEqual(resp.status_code, http_client.OK)
         self.impl.list.assert_called_with('test*', True, 'part1')
 
-    @unittest.skip('BROKEN: Flask exception handling')  # FIXME
     def test_get_state(self):
         """Test getting an instance state."""
         self.impl.get.return_value = {
@@ -110,7 +109,6 @@ class StateTest(unittest.TestCase):
         self.assertEqual(resp.status_code, http_client.OK)
         self.impl.get.assert_called_with('foo.bar#0000000001')
 
-    @unittest.skip('BROKEN: Flask exception handling')  # FIXME
     def test_get_state_notfound(self):
         """Test getting an instance state (not found)."""
         self.impl.get.return_value = None

--- a/lib/python/treadmill/tests/runtime/linux/image/tar_test.py
+++ b/lib/python/treadmill/tests/runtime/linux/image/tar_test.py
@@ -112,7 +112,7 @@ class TarImageTest(unittest.TestCase):
         )
 
         self.assertIsNotNone(img)
-        img.unpack(self.container_dir, self.root, self.app, {})
+        img.unpack(self.container_dir, self.root, self.app, {}, {})
 
     def test_get_tar__invalid_sha256(self):
         """Validates getting a test tar file with an invalid sha256 hash_code.

--- a/lib/python/treadmill/tests/runtime/linux/manifest_test.py
+++ b/lib/python/treadmill/tests/runtime/linux/manifest_test.py
@@ -137,6 +137,28 @@ class LinuxRuntimeManifestTest(unittest.TestCase):
 
         cmd = app_manifest._get_docker_run_cmd(
             name='foo',
+            image='test afterspace'
+        )
+        self.assertEqual(
+            cmd,
+            (
+                'exec $TREADMILL/bin/treadmill sproc docker'
+                ' --name foo'
+                ' --envdirs /env,/docker/env,/services/foo/env'
+                ' --volume /var/log:/var/log:rw'
+                ' --volume /var/spool:/var/spool:rw'
+                ' --volume /var/tmp:/var/tmp:rw'
+                ' --volume /docker/etc/hosts:/etc/hosts:ro'
+                ' --volume /docker/etc/passwd:/etc/passwd:ro'
+                ' --volume /docker/etc/group:/etc/group:ro'
+                ' --volume /env:/env:ro'
+                ' --volume /treadmill-bind:/opt/treadmill-bind:ro'
+                ' --image \'test afterspace\''
+            )
+        )
+
+        cmd = app_manifest._get_docker_run_cmd(
+            name='foo',
             image='testwt2',
             commands='/bin/sh -c "echo $foo $bar"',
         )

--- a/lib/python/treadmill/tests/sproc/nodeinfo_test.py
+++ b/lib/python/treadmill/tests/sproc/nodeinfo_test.py
@@ -39,22 +39,22 @@ class NodeinfoTest(unittest.TestCase):
     def test_get_rate_limit(self):
         """Test nodeinfo._get_rate_limit."""
         # pylint: disable=W0212
-        self.assertIsNone(nodeinfo._get_rate_limit(None, None))
+        self.assertIsNone(nodeinfo._get_rate_limit(None, None, None))
         self.assertDictEqual(
-            nodeinfo._get_rate_limit('1/second', None),
-            {'_global': '1/second'},
+            nodeinfo._get_rate_limit('1/second', None, 'user'),
+            {'_global': '1/second', '_limit_by': 'user'},
         )
         self.assertDictEqual(
-            nodeinfo._get_rate_limit(None, {'foo': '2/minutes'}),
+            nodeinfo._get_rate_limit(None, {'foo': '2/minutes'}, None),
             {'foo': '2/minutes'},
         )
         self.assertDictEqual(
-            nodeinfo._get_rate_limit('3/second', {'bar': '4/minutes'}),
-            {'_global': '3/second', 'bar': '4/minutes'},
+            nodeinfo._get_rate_limit('3/second', {'bar': '4/minutes'}, 'ip'),
+            {'_global': '3/second', 'bar': '4/minutes', '_limit_by': 'ip'},
         )
 
         with self.assertRaises(click.BadParameter):
-            nodeinfo._get_rate_limit(None, {'baz': 'invalid-rule-fmt'})
+            nodeinfo._get_rate_limit(None, {'baz': 'invalid-rule-fmt'}, None)
 
 
 if __name__ == '__main__':

--- a/lib/python/treadmill/tests/sproc/zk2fs_test.py
+++ b/lib/python/treadmill/tests/sproc/zk2fs_test.py
@@ -1,0 +1,51 @@
+"""Unit test for treadmill.sproc.zk2fs.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import unittest
+import mock
+
+import kazoo
+
+# Disable W0611: Unused import
+import treadmill.tests.treadmill_test_skip_windows  # pylint: disable=W0611
+
+from treadmill.sproc import zk2fs
+from treadmill.zksync import utils
+
+
+class Zk2FsTest(unittest.TestCase):
+    """Test treadmill.sproc.zk2fs"""
+
+    @mock.patch('treadmill.sproc.zk2fs.fs', mock.Mock())
+    def test_on_add_identity(self):
+        """Test _on_add_identity()"""
+        # pylint: disable=protected-access
+        zksync_mock = mock.Mock()
+        zk2fs._on_add_identity(zksync_mock, '/foo/bar')
+
+        self.assertTrue(zksync_mock.sync_children.called)
+        self.assertFalse(zksync_mock.sync_data.called)
+
+        zksync_mock.reset_mock()
+        zksync_mock.fpath.return_value = 'zkfs_root/foo/bar'
+        zk2fs._on_add_identity(zksync_mock, '/foo/bar', True)
+
+        self.assertTrue(zksync_mock.sync_children.called)
+        zksync_mock.sync_data.assert_called_once_with(
+            '/foo/bar',
+            os.path.join('zkfs_root/foo/bar', utils.NODE_DATA_FILE),
+            watch=True)
+
+        zksync_mock.sync_data.side_effect = kazoo.client.NoNodeError
+        # exception should be handled
+        zk2fs._on_add_identity(zksync_mock, '/foo/bar', True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/python/treadmill/tests/trace/app/zk_test.py
+++ b/lib/python/treadmill/tests/trace/app/zk_test.py
@@ -6,6 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
 import unittest
 import time
 import sqlite3
@@ -66,7 +67,12 @@ class AppTraceZKTest(mockzk.MockZookeeperTestCase):
             ),
             mock.call(
                 '/finished/foo.bar#123',
-                b'{data: test, host: baz, state: aborted, when: \'100\'}\n',
+                json.dumps({
+                    'data': 'test',
+                    'host': 'baz',
+                    'state': 'aborted',
+                    'when': '100'
+                }, sort_keys=True).encode(),
                 ephemeral=False, makepath=True, sequence=False,
                 acl=mock.ANY
             )

--- a/lib/python/treadmill/tests/trace_test.py
+++ b/lib/python/treadmill/tests/trace_test.py
@@ -6,6 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
 import os
 import shutil
 import tempfile
@@ -113,7 +114,12 @@ class TraceTest(mockzk.MockZookeeperTestCase):
             ),
             mock.call(
                 '/finished/foo.bar#123',
-                b'{data: test, host: baz, state: aborted, when: \'100\'}\n',
+                json.dumps({
+                    'data': 'test',
+                    'host': 'baz',
+                    'state': 'aborted',
+                    'when': '100'
+                }, sort_keys=True).encode(),
                 makepath=True,
                 ephemeral=False,
                 acl=mock.ANY,
@@ -215,7 +221,12 @@ class TraceTest(mockzk.MockZookeeperTestCase):
             ),
             mock.call(
                 '/finished/foo.bar#123',
-                b'{data: test, host: baz, state: aborted, when: \'100\'}\n',
+                json.dumps({
+                    'data': 'test',
+                    'state': 'aborted',
+                    'when': '100',
+                    'host': 'baz'
+                }, sort_keys=True).encode(),
                 ephemeral=False, makepath=True, sequence=False,
                 acl=mock.ANY
             )

--- a/lib/python/treadmill/tests/traits_test.py
+++ b/lib/python/treadmill/tests/traits_test.py
@@ -11,9 +11,9 @@ import unittest
 from treadmill import traits
 
 
-def _transform(code, traitz):
+def _transform(code, traitz, use_invalid=False):
     """Encode then decode traitz"""
-    return traits.format_traits(code, traits.encode(code, traitz))
+    return traits.format_traits(code, traits.encode(code, traitz, use_invalid))
 
 
 class TraitsTest(unittest.TestCase):
@@ -41,8 +41,20 @@ class TraitsTest(unittest.TestCase):
             'a,b'
         )
         self.assertEqual(
-            _transform({}, ['a', 'x', 'b']),
+            _transform(code, ['a', 'x', 'b'], use_invalid=True),
+            'a,b,invalid'
+        )
+        self.assertEqual(
+            _transform(traits.create_code([]), ['a', 'x', 'b']),
             ''
+        )
+        self.assertEqual(
+            _transform(
+                traits.create_code([]),
+                ['a', 'x', 'b'],
+                use_invalid=True
+            ),
+            'invalid'
         )
 
 

--- a/lib/python/treadmill/tests/zkutils_test.py
+++ b/lib/python/treadmill/tests/zkutils_test.py
@@ -104,13 +104,13 @@ class ZkTest(unittest.TestCase):
     def test_get(self):
         """Test zkutils.get parsing of YAML data."""
         client = treadmill.zkutils.ZkClient()
-        treadmill.zkutils.ZkClient.get.return_value = ('{xxx: 123}', None)
+        treadmill.zkutils.ZkClient.get.return_value = (b'{xxx: 123}', None)
         self.assertEqual({'xxx': 123}, zkutils.get(client, '/foo'))
 
         # parsing error
-        treadmill.zkutils.ZkClient.get.return_value = ('{xxx: 123', None)
+        treadmill.zkutils.ZkClient.get.return_value = (b'{xxx: 123', None)
         self.assertEqual(
-            '{xxx: 123',
+            b'{xxx: 123',
             zkutils.get(client, '/foo', strict=False)
         )
         self.assertRaises(yaml.YAMLError, zkutils.get, client, '/foo')

--- a/lib/python/treadmill/tests/zkwatchers_test.py
+++ b/lib/python/treadmill/tests/zkwatchers_test.py
@@ -45,7 +45,7 @@ class ZkwatchersTest(mockzk.MockZookeeperTestCase):
         # Test using ExistingDataWatch as a class
         foo_func = mock.Mock()
         zkwatchers.ExistingDataWatch(zkclient, '/foo', foo_func)
-        foo_func.assert_called_once_with('foo_data', mock.ANY, None)
+        foo_func.assert_called_once_with(b'foo_data', mock.ANY, None)
 
         # Test using ExistingDataWatch on a non-existing node
         bar_func = mock.Mock()
@@ -61,7 +61,7 @@ class ZkwatchersTest(mockzk.MockZookeeperTestCase):
         def _func(data, stat, event):
             baz_func(data, stat, event)
             baz_func_event.set()
-        baz_func.assert_called_once_with('baz_data', mock.ANY, None)
+        baz_func.assert_called_once_with(b'baz_data', mock.ANY, None)
         self.assertTrue(baz_func_event.is_set())
 
         foo_func.reset_mock()
@@ -81,11 +81,11 @@ class ZkwatchersTest(mockzk.MockZookeeperTestCase):
         baz_func_event.wait(timeout=1)
 
         foo_func.assert_called_once_with(
-            'foo_data', mock.ANY, ('CHANGED', 'CONNECTED', '/foo')
+            b'foo_data', mock.ANY, ('CHANGED', 'CONNECTED', '/foo')
         )
         self.assertEqual(bar_func.call_count, 0)
         baz_func.assert_called_once_with(
-            'baz_data', mock.ANY, ('CHANGED', 'CONNECTED', '/baz')
+            b'baz_data', mock.ANY, ('CHANGED', 'CONNECTED', '/baz')
         )
 
 

--- a/lib/python/treadmill/traits.py
+++ b/lib/python/treadmill/traits.py
@@ -13,6 +13,9 @@ from treadmill import sysinfo
 
 _LOGGER = logging.getLogger(__name__)
 
+# Invalid trait
+INVALID = 'invalid'
+
 
 def format_traits(code, value):
     """Format traits as list of names.
@@ -46,20 +49,20 @@ def detect(traits):
 def create_code(traits):
     """Assign bits to list of traits.
     """
-    if not traits:
-        return {}
-
-    result = {}
     code = 1
+    result = {INVALID: code}
+
+    if not traits:
+        return result
 
     for trait in traits:
-        result[trait] = code
         code = code << 1
+        result[trait] = code
 
     return result
 
 
-def encode(code, traits):
+def encode(code, traits, use_invalid=False):
     """Code the list of traits into a number.
     """
     result = 0
@@ -69,6 +72,8 @@ def encode(code, traits):
             result |= code[trait]
         else:
             _LOGGER.error('Unknown trait %s', trait)
+            if use_invalid:
+                result |= code[INVALID]
 
     return result
 

--- a/lib/python/treadmill/utils.py
+++ b/lib/python/treadmill/utils.py
@@ -624,7 +624,9 @@ else:
 def get_ulimit(u_type):
     """get ulimit value
     resource type name nofile => RLIMIT_NOFILE
-    return tuple of (soft_limit, hard_limit)
+
+    :returns:
+        ``tuple(int, int)`` --  Tuple of (soft_limit, hard_limit).
     """
     type_name = 'RLIMIT_{}'.format(u_type.upper())
     return resource.getrlimit(getattr(resource, type_name))

--- a/lib/python/treadmill/webutils.py
+++ b/lib/python/treadmill/webutils.py
@@ -148,25 +148,21 @@ def cors(origin=None, methods=None, headers=None, max_age=21600,
     return decorator
 
 
-def log_header(header=None):
-    # pylint: disable=R0912
-    """Flask decorator to log headers or a specific header
-
-    :param header:
-        This can be a string as to which header to log
+def log_request():
+    """Flask decorator to log request
     """
     def decorator(func):
         """Function decorator to log header(s)"""
         def wrapped_function(*args, **kwargs):
             """Wrapper function to add required headers."""
+            _LOGGER.info(
+                'source: %s, path: %s, header: %r',
+                flask.request.remote_addr,
+                flask.request.full_path,
+                flask.request.headers
+            )
+
             resp = flask.make_response(func(*args, **kwargs))
-
-            headers = flask.request.headers
-            if header is not None:
-                _LOGGER.info('header: %s: %r', header, headers.get(header))
-                return resp
-
-            _LOGGER.info('headers: %r', headers)
             return resp
 
         func.provide_automatic_options = False
@@ -250,7 +246,7 @@ def get_api(api, cors_handler, marshal=None, resp_model=None,
     funcs = [
         cors_handler,
         no_cache,
-        log_header(),
+        log_request(),
     ]
 
     if json_resp:
@@ -285,7 +281,7 @@ def _common_api(api, cors_handler, marshal=None, req_model=None,
     funcs = [
         cors_handler,
         no_cache,
-        log_header(),
+        log_request(),
         as_json,
         api.doc(responses={
             403: 'Not Authorized',

--- a/lib/python/treadmill/zksync/utils.py
+++ b/lib/python/treadmill/zksync/utils.py
@@ -14,7 +14,7 @@ import time
 from treadmill import utils
 
 MODIFIED = '.modified'
-
+NODE_DATA_FILE = '.data'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Jinja2>=2.9,<3
 jsonschema>=2.5,<3
 kazoo>=2.2,<3
 ldap3>=2.3,<3
+ldif3>=3,<4
 Limits>=1.3,<2
 netifaces>=0.10,<0.11,!=0.10.8
 Numpy>=1.13,<2


### PR DESCRIPTION
 * Fix mutiple worker for API
 * docker: Add support for list of registries by environment.
 * Keytabs locker version 2
 * Refactor ephemeral port thing with different approaches
 * admin: fix compat layer
 * Fix a bug causing some init apps keep creating svc folders without
   root privilege.
 * fix allocation api plugin loading
 * Change CPU type from int to str in manifest docs.
 * admin.ldap: Add support for list,dump,set,get,delete commands
 * Missing traits in 'treadmill cell configure xxxx'
 * Enable zk2fs to dump keytab-locker paths
 * Add archive back to the app rest data model.
 * cli.error => cli.out
 * scheduler cli: only replace False with X in explain
 * runtime: Fix passing through of host devices
 * Admin Ldap Allocation Full Rework
 * Fix a bug causing failures to update
   rank/rank-adjustment/max-utilization/traits in reservation.
 * runtime: Fix passing through of host devices
 * Better cli message blocked by rate limit
 * Fixed a conflict between coverage and mocking islink.
 * fix alert_monitor can wipe temp file created during write_safe
 * temporarily add back archive in api schema
 * Fix bulk_update/delete for personal containers.
 * log api request (source_ip, path, header)
 * extra_dev: Fix bad mknod call when bringing in extra devices
 * zk2fs: ability to sync the metadata of identity-groups.
 * fix unit test
 * configurable volume mapping
 * Add zk-admins variable to Zookeeper bootstrap
 * add traits option to treadmill run
 * Supports authenticated user as rate limiting key
 * Update manifest doc for 3.8
 * add traits option to treadmill run
 * Allow configurating container visible host devices
 * Spawn watch_manifest - don't crash on UnicodeDecodeError when reading
   manifest.
 * add basic traits documentation
 * added common list for master indexes to prevent further discrepancies
 * Fix string after space in image can be regarded as docker cmd parameter
 * Remove conflicting error handler for kazoo.exceptions.KazooException (500).
 * Fix flaky flask-restplus errorhandlers.
 * Adding Docker troubleshooting steps
 * have a built-in "invalid" trait
 * Fix global rate limit
 * Fix tktfwd install (new bootstrap).
 * Admin - add option to get operational attrs (create/modifyTimestamp)
   on get and list.
 * Serialize objects as json rather than yaml.
 * better allocation docs
 * Allow override of api DNS srv records resolution.
 * Fix - do not check executable bit for shared libs.
 * display merged traits in scheduler view apps