### PR TITLE
Sync with 2019.04.24-1

### DIFF
--- a/entry_points.txt
+++ b/entry_points.txt
@@ -99,6 +99,7 @@ authz-group = treadmill.api.authz.group
 [treadmill.api.allocation.plugins]
 
 [treadmill.websocket.api]
+app-group = treadmill.websocket.api.app_group
 endpoint = treadmill.websocket.api.endpoint
 identity-group = treadmill.websocket.api.identity_group
 state = treadmill.websocket.api.state
@@ -224,6 +225,7 @@ server = treadmill.cli.admin.ldap.server
 tenant = treadmill.cli.admin.ldap.tenant
 
 [treadmill.cli.admin.checkout]
+ldap = treadmill.cli.admin.checkout.ldap
 zk = treadmill.cli.admin.checkout.zk
 servers = treadmill.cli.admin.checkout.servers
 

--- a/lib/python/treadmill/api/authz/group.py
+++ b/lib/python/treadmill/api/authz/group.py
@@ -79,25 +79,34 @@ class API:
                 try:
                     group = grp.getgrnam(group_name)
                     members = group.gr_mem
-                    _LOGGER.info(
-                        'Authorized: User %s is member of %s.',
-                        username,
-                        group_name
-                    )
 
                     if username in members:
+                        _LOGGER.info(
+                            'Authorized: User %s is member of %s.',
+                            username,
+                            group_name
+                        )
                         return True, why
                     else:
+                        _LOGGER.debug(
+                            'User %s not in %s', username, group_name
+                        )
                         why.append(
-                            '{} not member of {}'.format(
+                            '{} not in {}'.format(
                                 username,
                                 group_name
                             )
                         )
                 except KeyError:
-                    _LOGGER.info('Group does not exist: %s', group_name)
+                    _LOGGER.info(
+                        'Group does not exist: %s', group_name
+                    )
                     why.append('no such group: {}'.format(group_name))
 
+            _LOGGER.info(
+                'Not authorized: %s %s %s %s',
+                user, action, resource, resource_id
+            )
             return False, why
 
         self.authorize = authorize

--- a/lib/python/treadmill/appcfg/manifest.py
+++ b/lib/python/treadmill/appcfg/manifest.py
@@ -127,6 +127,7 @@ def load(event):
     _set_default('vring', {})
     _set_default('cells', [], manifest['vring'])
     _set_default('identity_group', None)
+    _set_default('identity_count', None)
     _set_default('identity', None)
     _set_default('data_retention_timeout', None)
     _set_default('lease', None)

--- a/lib/python/treadmill/bootstrap/node/__init__.py
+++ b/lib/python/treadmill/bootstrap/node/__init__.py
@@ -46,6 +46,7 @@ DEFAULTS = {
         '/,/dev*,/proc*,/sys*,/run*,/mnt*,'
     ),
     'docker_network': 'nat',
+    'zookeeper_session_timeout': None,
 }
 
 ALIASES = aliases.ALIASES

--- a/lib/python/treadmill/bootstrap/node/linux/env/TREADMILL_ZOOKEEPER_SESSION_TIMEOUT
+++ b/lib/python/treadmill/bootstrap/node/linux/env/TREADMILL_ZOOKEEPER_SESSION_TIMEOUT
@@ -1,0 +1,1 @@
+{{ zookeeper_session_timeout or '' }}

--- a/lib/python/treadmill/bootstrap/node/windows/env/TREADMILL_ZOOKEEPER_SESSION_TIMEOUT
+++ b/lib/python/treadmill/bootstrap/node/windows/env/TREADMILL_ZOOKEEPER_SESSION_TIMEOUT
@@ -1,0 +1,1 @@
+{{ zookeeper_session_timeout or '' }}

--- a/lib/python/treadmill/cli/__init__.py
+++ b/lib/python/treadmill/cli/__init__.py
@@ -162,6 +162,8 @@ def handle_context_opt(ctx, param, value):
         context.GLOBAL.ldap.password = _read_password(value)
     elif opt == 'zookeeper':
         context.GLOBAL.zk.url = value
+    elif opt == 'zookeeper_session_timeout':
+        context.GLOBAL.zk.session_timeout = value
     elif opt == 'profile':
         context.GLOBAL.set_profile_name(value)
         init_profile()

--- a/lib/python/treadmill/cli/admin/checkout/__init__.py
+++ b/lib/python/treadmill/cli/admin/checkout/__init__.py
@@ -55,10 +55,11 @@ def _print_check_result(description, data, status):
 def _run_check(conn, check, verbose, index_col):
     """Run check."""
     query = check['query']
-    metric = check['metric']
     alerts = check.get('alerts', [])
 
-    cursor = conn.execute(metric.format(query=query))
+    metric_sql = check['metric'].format(query=query)
+    _LOGGER.debug('metric_sql: %s', metric_sql)
+    cursor = conn.execute(metric_sql)
     check_failed = False
     empty = True
     for row in cursor:

--- a/lib/python/treadmill/cli/admin/checkout/ldap.py
+++ b/lib/python/treadmill/cli/admin/checkout/ldap.py
@@ -1,0 +1,212 @@
+"""Checkout ldap servers ensemble.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+import logging
+
+import click
+import ldap3
+
+from treadmill import admin
+from treadmill import cli
+from treadmill import context
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _metadata(total, accuracy):
+    """genertate metadata for alerts
+    """
+    return {
+        'index': 'name',
+        'query': 'select * from ldap_server_csn',
+        'checks': [
+            {
+                'description': 'LDAP Status',
+                'query':
+                    """
+                    select name, health from ldap_status where health == 0
+                    order by name
+                    """,
+                'metric':
+                    """
+                    select count(*) as down from ({query})
+                    """,
+                'alerts': [
+                    {
+                        'description': 'All LDAP servers are up',
+                        'severity': 'error',
+                        'threshold': {
+                            'down': 1
+                        }
+                    },
+                    {
+                        'description': 'LDAP server group is working',
+                        'severity': 'critical',
+                        'threshold': {
+                            'down': total
+                        }
+                    }
+                ]
+            },
+            {
+                'description': 'LDAP ContextCSN',
+                'query':
+                    """
+                    select name, csn_timestamp, csn_id
+                    from ldap_server_csn order by csn_id, name
+                    """,
+                'metric':
+                    """
+                    select count(*) as async
+                    from ldap_server_csn ls, (
+                        select max(csn_timestamp) as csn_timestamp,
+                        csn_id from ldap_server_csn group by csn_id
+                    ) q
+                    where ls.csn_id == q.csn_id
+                    and (q.csn_timestamp - %d) > (ls.csn_timestamp + 0)
+                    """ % accuracy,
+                'alerts': [
+                    {
+                        'description': 'LDAP servers are synchronized',
+                        'severity': 'critical',
+                        'threshold': {
+                            'async': 1
+                        }
+                    }
+                ]
+            },
+            {
+                'description': 'LDAP schema',
+                'query':
+                    """
+                    select name, schema
+                    from ldap_schema order by name
+                    """,
+                'metric':
+                    """
+                    select count(*) as total
+                    from (
+                        select distinct(schema) from ldap_schema
+                    )
+                    """,
+                'alerts': [
+                    {
+                        'description': 'LDAP schemas are synchronized',
+                        'severity': 'critical',
+                        'threshold': {
+                            'total': 2
+                        }
+                    }
+                ]
+            }
+        ]  # end of 'checks'
+    }
+
+
+def init():
+    """Top level command handler."""
+
+    @click.command('ldap')
+    @click.option('--ldap-list', required=True,
+                  envvar='TREADMILL_LDAP_LIST', type=cli.LIST)
+    @click.option('--accuracy', required=False, type=int, default=200,
+                  help=(
+                      'allow slight inconsistent CSN timestamp in centisecond.'
+                      'Default: 200 centi-second'
+                  ))
+    def check_ldap_servers(ldap_list, accuracy):
+        """Check ldap server status."""
+
+        def _check(conn, **_kwargs):
+            """LDAP Server state: """
+            ldap_suffix = context.GLOBAL.ldap_suffix
+
+            conn.execute(
+                """
+                CREATE TABLE ldap_server_csn (
+                    name text,
+                    csn_timestamp integer,
+                    csn_id text
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE ldap_status (
+                    name text,
+                    health integer
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE ldap_schema (
+                    name text,
+                    schema text
+                )
+                """
+            )
+
+            rows = []
+            status = []
+            schemas = []
+            # we fetch contextCSN of each ldap server to check consistency
+            for ldap_url in ldap_list:
+                # pylint: disable=protected-access
+                ldap_conn = admin._ldap.Admin([ldap_url], ldap_suffix)
+                try:
+                    ldap_conn.connect()
+                    context_csn = ldap_conn.get(
+                        dn='dc=ms,dc=com',
+                        query='(objectclass=*)',
+                        attrs=ldap3.ALL_OPERATIONAL_ATTRIBUTES
+                    )['contextCSN']
+                    _LOGGER.debug(
+                        'Raw contextCSN: %s => %r', ldap_url, context_csn
+                    )
+                    schema = ldap_conn.schema()
+                    _LOGGER.debug(
+                        'schema: %s => %r', ldap_url, schema
+                    )
+                    schema_str = json.dumps(schema, sort_keys=True)
+                    ldap_conn.close()
+
+                    for csn in context_csn:
+                        (csn_timestamp, _, csn_id, _) = csn.split('#')
+                        rows.append((ldap_url, csn_timestamp, csn_id))
+
+                    status.append((ldap_url, 1))
+                    schemas.append((ldap_url, schema_str))
+                except KeyError:
+                    # contextCSN may not have been generated in ldap
+                    status.append((ldap_url, 0))
+                except ldap3.core.exceptions.LDAPBindError:
+                    status.append((ldap_url, 0))
+
+            conn.executemany(
+                """
+                INSERT INTO ldap_server_csn(name, csn_timestamp, csn_id)
+                values(?, ?, ?)
+                """,
+                rows
+            )
+            conn.executemany(
+                'INSERT INTO ldap_status(name, health) values(?, ?)',
+                status
+            )
+            conn.executemany(
+                'INSERT INTO ldap_schema(name, schema) values(?, ?)',
+                schemas
+            )
+
+            return _metadata(len(ldap_list), accuracy)
+
+        return _check
+
+    return check_ldap_servers

--- a/lib/python/treadmill/cli/admin/krb/forward.py
+++ b/lib/python/treadmill/cli/admin/krb/forward.py
@@ -7,15 +7,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
-import sys
 
 import click
 
 from treadmill import cli
 from treadmill import context
 from treadmill import discovery
-from treadmill import krb
 from treadmill import exc
+from treadmill import tickets
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,24 +41,31 @@ def init():
     @click.command()
     @click.option('--cell', required=True,
                   envvar='TREADMILL_CELL',
-                  callback=cli.handle_context_opt)
+                  callback=cli.handle_context_opt,
+                  expose_value=False)
     @click.option('--proid', required=True, help='Proid.')
-    @click.option('--spn', default=None,
-                  help='Service Principal Name used in the Kerberos protocol.')
+    @click.option('--receiver', required=False, type=cli.LIST,
+                  help='list of receiver host:port')
     @click.argument('endpoint', required=False)
     @_ON_EXCEPTIONS
-    def forward(endpoint, spn, proid, cell):
+    def forward(endpoint, proid, receiver):
         """Forward Kerberos tickets to the cell ticket locker."""
         _LOGGER.setLevel(logging.INFO)
         if not endpoint:
             endpoint = '*'
 
-        pattern = "{0}.tickets-v2".format(proid)
-        discovery_iter = discovery.iterator(
-            context.GLOBAL.zk.conn, pattern, endpoint, False)
-        hostports = _iterate(discovery_iter)
+        if not receiver:
+            pattern = "{0}.ticketsreceiver".format(proid)
+            discovery_iter = discovery.iterator(
+                context.GLOBAL.zk.conn, pattern, endpoint, False)
+            hostports = _iterate(discovery_iter)
+        else:
+            hostports = []
+            for hostport in receiver:
+                host, port = hostport.split(':')
+                hostports.append((host, int(port)))
 
-        failure = krb.forward(cell, hostports, tktfwd_spn=spn)
-        sys.exit(failure)
+        for host, port in hostports:
+            tickets.forward(host, int(port))
 
     return forward

--- a/lib/python/treadmill/context.py
+++ b/lib/python/treadmill/context.py
@@ -301,6 +301,7 @@ class ZkContext:
         '_conn',
         '_listeners',
         'idpath',
+        'session_timeout',
     )
 
     def __init__(self, ctx):
@@ -308,6 +309,7 @@ class ZkContext:
         self._conn = None
         self._listeners = []
         self.idpath = None
+        self.session_timeout = None
 
     def add_listener(self, listener):
         """Add a listener.
@@ -337,7 +339,11 @@ class ZkContext:
         _LOGGER.debug('Connecting to Zookeeper %s', self.url)
 
         plugin = plugin_manager.load('treadmill.context', 'zookeeper')
-        self._conn = plugin.connect(self.url, idpath=self.idpath)
+        self._conn = plugin.connect(
+            self.url,
+            idpath=self.idpath,
+            session_timeout=self.session_timeout
+        )
         if self._listeners:
             for listener in self._listeners:
                 self._conn.add_listener(listener)

--- a/lib/python/treadmill/etc/schema/app_event.json
+++ b/lib/python/treadmill/etc/schema/app_event.json
@@ -1,9 +1,18 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "resource_id": {
-        "type": "string",
-        "maxLength": 60,
-        "pattern": "^[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9\\-_^#]+)+$"
+        "anyOf": [
+            {
+                "type": "string",
+                "maxLength": 127,
+                "pattern": "^[\\w\\-]+(\\.[\\w\\-^#]+)+$"
+            },
+            {
+                "type": "string",
+                "maxLength": 127,
+                "pattern": "^[\\w\\-]+@[\\w\\-]+(\\.[\\w\\-^#]+)+$"
+            }
+        ]
     },
     "resource": {
         "type": "object",
@@ -12,11 +21,19 @@
             "cells": {
                 "type": "array",
                 "items": { "$ref": "common.json#/cell" },
-                "minItems": 1
+                "minItems": 0
             },
             "pattern": {
-                "type": "string",
-                "pattern": "^[a-zA-Z0-9_-]+\\..+$"
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "pattern": "^[\\w\\-]+\\..+$"
+                    },
+                    {
+                        "type": "string",
+                        "pattern": "^[\\w\\-]+\\@[\\w\\-]+\\..+$"
+                    }
+                ]
             },
             "pending": {
                 "type": "integer",

--- a/lib/python/treadmill/etc/schema/websocket/app_group.json
+++ b/lib/python/treadmill/etc/schema/websocket/app_group.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "message": {
+        "type": "object",
+        "properties": {
+            "sub-id": { "$ref": "common.json#/message/sub-id" },
+            "topic": { "$ref": "common.json#/message/topic" },
+            "since": { "$ref": "common.json#/message/since" },
+            "snapshot": { "$ref": "common.json#/message/snapshot" },
+            "app-group": {
+                "type": "string",
+                "maxLength": 128,
+                "pattern": "^[\\w\\-\\.\\*\\[\\]\\?]+$"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "topic" ]
+    }
+}

--- a/lib/python/treadmill/iptables.py
+++ b/lib/python/treadmill/iptables.py
@@ -21,6 +21,7 @@ except ImportError:
     import xml.etree.ElementTree as etree
 
 from treadmill import firewall
+from treadmill import netdev
 from treadmill import subproc
 
 from treadmill import templates
@@ -177,6 +178,12 @@ def initialize(external_ip):
     :param ``str`` external_ip:
         External IP to use with NAT rules
     """
+    # Exclude all *our* ports from the default ephemeral port range.
+    netdev.net_conf_ip_port_range(
+        max(NONPROD_PORT_HIGH, PROD_PORT_HIGH) + 1,  # Highest in PROD/NONPROD
+        65535                                        # Default
+    )
+
     # Ensure all the IPSets exists.
     ipsets_ensure_exist()
 
@@ -267,6 +274,12 @@ def initialize_container():
 
     It is assumed that none but Treadmill manages these tables.
     """
+    # Exclude all *our* ports from the default ephemeral port range.
+    netdev.net_conf_ip_port_range(
+        max(NONPROD_PORT_HIGH, PROD_PORT_HIGH) + 1,  # Highest in PROD/NONPROD
+        65535                                        # Default
+    )
+    # Load empty default rules.
     _iptables_restore(templates.render(IPTABLES_EMPTY_RESTORE))
 
 

--- a/lib/python/treadmill/keytabs2.py
+++ b/lib/python/treadmill/keytabs2.py
@@ -182,15 +182,27 @@ def get_listening_server(locker, port):
             }
             return _response(success=True, keytabs=keytabs)
 
+        def _delete(self, req):
+            """delete keytab if removed
+            """
+            try:
+                keytab = req['keytab']
+            except KeyError:
+                raise _KeytabLockerError('No "keytab" in request')
+
+            _LOGGER.info('Delete keytab: %s', keytab)
+            fs.rm_safe(os.path.join(locker.kt_spool_dir, keytab))
+            return _response(success=True)
+
         def _put(self, req):
             """Store encoded keytab.
             """
             try:
                 keytab, encoded = req['keytab'], req['encoded']
             except KeyError:
-                raise _KeytabLockerError('Miss "keytab" or "encoded"')
+                raise _KeytabLockerError('No "keytab" or "encoded" in request')
 
-            _LOGGER.info('put %s - %s',
+            _LOGGER.info('Put keytab: %s - %s',
                          keytab,
                          hashlib.sha1(encoded).hexdigest())
 
@@ -208,6 +220,8 @@ def get_listening_server(locker, port):
                     return self._get(request)
                 elif action == 'put':
                     return self._put(request)
+                elif action == 'del':
+                    return self._delete(request)
                 else:
                     return _response(success=False, message='Unknown Action')
 

--- a/lib/python/treadmill/netdev.py
+++ b/lib/python/treadmill/netdev.py
@@ -27,6 +27,7 @@ _PROC_CONF_PROXY_ARP = '/proc/sys/net/ipv4/conf/{dev}/proxy_arp'
 _PROC_CONF_FORWARDING = '/proc/sys/net/ipv4/conf/{dev}/forwarding'
 _PROC_CONF_ARP_IGNORE = '/proc/sys/net/ipv4/conf/{dev}/arp_ignore'
 _PROC_CONF_ROUTE_LOCALNET = '/proc/sys/net/ipv4/conf/{dev}/route_localnet'
+_PROC_NET_LOCAL_PORT_RANGE = '/proc/sys/net/ipv4/ip_local_port_range'
 
 
 def dev_mtu(devname):
@@ -510,6 +511,20 @@ def gre_delete(grename):
             'del', grename,
             'mode', 'gre',
         ],
+    )
+
+
+def net_conf_ip_port_range(lower, upper):
+    """Configure the usable ephemeral port range.
+    """
+    assert lower <= upper
+
+    _proc_sys_write(
+        _PROC_NET_LOCAL_PORT_RANGE,
+        '{lower:d} {upper:d}'.format(
+            lower=lower,
+            upper=upper
+        )
     )
 
 

--- a/lib/python/treadmill/runtime/docker/runtime.py
+++ b/lib/python/treadmill/runtime/docker/runtime.py
@@ -53,6 +53,7 @@ def _create_environ(app):
         'TREADMILL_APP': app.app,
         'TREADMILL_INSTANCEID': app.task,
         'TREADMILL_IDENTITY': app.identity,
+        'TREADMILL_IDENTITY_COUNT': app.identity_count,
         'TREADMILL_IDENTITY_GROUP': app.identity_group,
         'TREADMILL_PROID': app.proid,
         'TREADMILL_ENV': app.environment,

--- a/lib/python/treadmill/runtime/linux/image/native.py
+++ b/lib/python/treadmill/runtime/linux/image/native.py
@@ -46,6 +46,7 @@ def create_environ_dir(container_dir, root_dir, app):
         'TREADMILL_DISK': app.disk,
         'TREADMILL_HOST_IP': app.network.external_ip,
         'TREADMILL_IDENTITY': app.identity,
+        'TREADMILL_IDENTITY_COUNT': app.identity_count,
         'TREADMILL_IDENTITY_GROUP': app.identity_group,
         'TREADMILL_INSTANCEID': app.task,
         'TREADMILL_MEMORY': app.memory,
@@ -655,8 +656,8 @@ class NativeImage(_image_base.Image):
         create_supervision_tree(
             self.tm_env, container_dir, root_dir, app,
             cgroups_path=cgroups.makepath(
-                'memory', cgrp
-            )
+                'freezer', cgrp
+            ),
         )
         create_overlay(self.tm_env, container_dir, root_dir, app)
 

--- a/lib/python/treadmill/scheduler/master.py
+++ b/lib/python/treadmill/scheduler/master.py
@@ -424,8 +424,16 @@ class Master(loader.Loader):
 
     def _placement_data(self, app):
         """Return placement data for given app."""
+        identity = self.cell.apps[app].identity
+        identity_group_ref = self.cell.apps[app].identity_group_ref
+
+        identity_count = None
+        if identity is not None and identity_group_ref is not None:
+            identity_count = identity_group_ref.count
+
         return {
-            'identity': self.cell.apps[app].identity,
+            'identity': identity,
+            'identity_count': identity_count,
             'expires': self.cell.apps[app].placement_expiry
         }
 

--- a/lib/python/treadmill/sproc/init.py
+++ b/lib/python/treadmill/sproc/init.py
@@ -57,9 +57,12 @@ def init():
 
         tm_env = appenv.AppEnvironment(approot)
         stop_on_lost = functools.partial(_stop_on_lost, tm_env)
-        zkclient = zkutils.connect(context.GLOBAL.zk.url,
-                                   idpath=zkid,
-                                   listener=stop_on_lost)
+        zkclient = zkutils.connect(
+            context.GLOBAL.zk.url,
+            idpath=zkid,
+            listener=stop_on_lost,
+            session_timeout=context.GLOBAL.zk.session_timeout
+        )
 
         while not zkclient.exists(z.SERVER_PRESENCE):
             _LOGGER.warning('namespace not ready.')

--- a/lib/python/treadmill/supervisor/__init__.py
+++ b/lib/python/treadmill/supervisor/__init__.py
@@ -128,7 +128,8 @@ def open_service(service_dir, existing=True):
 
 # Disable W0613: Unused argument 'kwargs' (for s6/winss compatibility)
 # pylint: disable=W0613
-def _create_scan_dir_s6(scan_dir, finish_timeout, wait_cgroups=None,
+def _create_scan_dir_s6(scan_dir, finish_timeout,
+                        wait_cgroups=None,
                         kill_svc=None, **kwargs):
     """Create a scan directory.
 

--- a/lib/python/treadmill/templates/s6.svscan.finish
+++ b/lib/python/treadmill/templates/s6.svscan.finish
@@ -54,6 +54,21 @@
                             {{ _alias.exit }} 0
                     }
             }
+            {{ _alias.foreground }} {
+                {{ _alias.forbacktickx }} -o 0 STATE_FILE
+                    {
+                        {{ _alias.find }}  {{ wait_cgroups }} -depth -name freezer.state
+                    }
+                    {{ _alias.importas }} -nu STATE_FILE STATE_FILE
+                    {{ _alias.foreground }} {
+                        {{ _alias.echo }} "Thawing ${STATE_FILE}"
+                    }
+                    {{ _alias.foreground }} {
+                        {{ _alias.redirfd }} -w 1 ${STATE_FILE}
+                        {{ _alias.echo }} "THAWED"
+                    }
+                    {{ _alias.exit }} 0
+            }
             {{ _alias.exit }} 0
         }
         {

--- a/lib/python/treadmill/tests/iptables_test.py
+++ b/lib/python/treadmill/tests/iptables_test.py
@@ -74,6 +74,8 @@ class IptablesTest(unittest.TestCase):
     @mock.patch('treadmill.iptables.create_chain', mock.Mock(set_spec=True))
     @mock.patch('treadmill.iptables._iptables_restore',
                 mock.Mock(set_spec=True))
+    @mock.patch('treadmill.netdev.net_conf_ip_port_range',
+                mock.Mock(set_spec=True))
     def test_initialize(self):
         """Test iptables initialization"""
         # Disable protected-access: Test access protected members .
@@ -82,6 +84,7 @@ class IptablesTest(unittest.TestCase):
         # NOTE: keep this IP in sync with the tests' state file dumps
         iptables.initialize('1.2.3.4')
 
+        treadmill.netdev.net_conf_ip_port_range(49152, 65535)
         treadmill.iptables.ipset_restore.assert_called_with(
             self.ipset_state
         )
@@ -121,11 +124,14 @@ class IptablesTest(unittest.TestCase):
             use_except=True
         )
 
+    @mock.patch('treadmill.netdev.net_conf_ip_port_range',
+                mock.Mock(set_spec=True))
     @mock.patch('treadmill.subproc.invoke', mock.Mock(return_value=(0, '')))
     def test_initialize_container(self):
         """Test iptables container initialization"""
         iptables.initialize_container()
 
+        treadmill.netdev.net_conf_ip_port_range(49152, 65535)
         treadmill.subproc.invoke.assert_called_with(
             ['iptables_restore'],
             cmd_input=self.iptables_empty_state,

--- a/lib/python/treadmill/tests/netdev_test.py
+++ b/lib/python/treadmill/tests/netdev_test.py
@@ -527,6 +527,19 @@ class NetDevTest(unittest.TestCase):
         )
 
     @mock.patch('io.open', mock.mock_open())
+    def test_net_conf_ip_port_range(self):
+        """Test enabling to local network routing on interface.
+        """
+        mock_handle = io.open.return_value
+
+        netdev.net_conf_ip_port_range(42, 43)
+
+        io.open.assert_called_with(
+            '/proc/sys/net/ipv4/ip_local_port_range', 'w'
+        )
+        mock_handle.write.assert_called_with('42 43')
+
+    @mock.patch('io.open', mock.mock_open())
     def test_dev_conf_route_lnet_set(self):
         """Test enabling to local network routing on interface.
         """

--- a/lib/python/treadmill/tests/runtime/docker/runtime_test.py
+++ b/lib/python/treadmill/tests/runtime/docker/runtime_test.py
@@ -59,6 +59,7 @@ class DockerRuntimeTest(unittest.TestCase):
             'name': 'proid.app#001',
             'uniqueid': 'abcdefghijklm',
             'identity': None,
+            'identity_count': None,
             'identity_group': None,
             'proid': 'proid',
             'environment': 'dev',

--- a/lib/python/treadmill/tests/runtime/linux/image/native_test.py
+++ b/lib/python/treadmill/tests/runtime/linux/image/native_test.py
@@ -392,14 +392,14 @@ class NativeImageTest(unittest.TestCase):
             base_dir,
             os.path.join(base_dir, 'root'),
             app,
-            '/test/cgroup/path'
+            '/test/cgroup/path',
         )
 
         treadmill.supervisor.create_scan_dir.assert_has_calls([
             mock.call(
                 os.path.join(base_dir, 'sys'),
                 finish_timeout=6000,
-                wait_cgroups='/test/cgroup/path'
+                wait_cgroups='/test/cgroup/path',
             ),
             mock.call().write(),
             mock.call(

--- a/lib/python/treadmill/tests/websocket/api/app_group_test.py
+++ b/lib/python/treadmill/tests/websocket/api/app_group_test.py
@@ -1,0 +1,90 @@
+"""Unit test for app_group websocket API.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+import jsonschema
+import six
+
+from treadmill.websocket.api import app_group
+
+
+class WSAppGroupAPITest(unittest.TestCase):
+    """Tests for app group websocket API."""
+
+    def test_subscribe(self):
+        """Test subscription registration."""
+        api = app_group.AppGroupAPI()
+        self.assertEqual(
+            [('/app-groups', 'foo.bar')],
+            api.subscribe({'topic': '/app-groups',
+                           'app-group': 'foo.bar'})
+        )
+
+        self.assertEqual(
+            [('/app-groups', 'foo.*')],
+            api.subscribe({'topic': '/app-groups',
+                           'app-group': 'foo.*'})
+        )
+
+        self.assertEqual(
+            [('/app-groups', '*')],
+            api.subscribe({'topic': '/app-groups'})
+        )
+
+        with six.assertRaisesRegex(self,
+                                   jsonschema.exceptions.ValidationError,
+                                   '\'filter\' was unexpected'):
+            api.subscribe({'topic': '/app-groups',
+                           'filter': 'foo!'})
+
+        with six.assertRaisesRegex(self,
+                                   jsonschema.exceptions.ValidationError,
+                                   'None is not of type u?\'string\''):
+            api.subscribe({'topic': '/app-groups',
+                           'app-group': None})
+
+    def test_on_event(self):
+        """Tests payload generation."""
+        api = app_group.AppGroupAPI()
+        self.assertEqual(
+            {'topic': '/app-groups',
+             'app-group': 'foo.bar',
+             'cells': ['mycell'],
+             'endpoints': [],
+             'group-type': 'event',
+             'pattern': 'foo.wsapi',
+             'data': {
+                 'exit': 'aborted',
+                 'pending': '10',
+             },
+             'sow': True},
+            api.on_event(
+                '/app-groups/foo.bar',
+                None,
+                """
+                {"cells": ["mycell"], "data": ["exit=aborted", "pending=10"],
+                "endpoints": [], "group-type": "event",
+                "pattern": "foo.wsapi"}
+                """
+            )
+        )
+        self.assertEqual(
+            {'topic': '/app-groups',
+             'app-group': 'foo.bar',
+             'sow': False},
+            api.on_event(
+                '/app-groups/foo.bar',
+                'd',
+                None
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/python/treadmill/tickets/locker.py
+++ b/lib/python/treadmill/tickets/locker.py
@@ -26,8 +26,6 @@ from treadmill import zkutils
 
 _LOGGER = logging.getLogger(__name__)
 
-_DIRWATCH_EVENTS_COUNT = 10
-
 
 class TicketLocker:
     """Manages ticket exchange between ticket locker and the container."""

--- a/lib/python/treadmill/tickets/receiver.py
+++ b/lib/python/treadmill/tickets/receiver.py
@@ -1,0 +1,59 @@
+"""Ticket locker server."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import hashlib
+import io
+import logging
+import os
+
+from twisted.internet import reactor
+from twisted.internet import protocol
+
+from treadmill import gssapiprotocol
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Disable warning for too many branches.
+# pylint: disable=R0912
+def run_server(port, tktdir):
+    """Runs tickets server."""
+    _LOGGER.info('Tickets receiver server starting.')
+
+    # no __init__ method.
+    #
+    # pylint: disable=W0232
+    class TicketReceiverServer(gssapiprotocol.GSSAPILineServer):
+        """Ticket receiver server."""
+
+        # @utils.exit_on_unhandled
+        def got_line(self, data):
+            """Invoked after authentication is done, decrypted data as arg.
+
+            :param ``bytes`` data:
+                Data received from the client.
+            """
+            _LOGGER.info('Accepted connection from %s', self.peer())
+            tkt = data
+            tkt_file = os.path.join(tktdir, self.peer())
+            _LOGGER.info('Writing: %s %s',
+                         tkt_file, hashlib.sha1(tkt).hexdigest())
+            with io.open(tkt_file, 'wb') as f:
+                f.write(tkt)
+
+            self.write(b'success')
+
+    class TicketReceiverServerFactory(protocol.Factory):
+        """TicketReceiverServer factory."""
+
+        def buildProtocol(self, addr):  # pylint: disable=C0103
+            return TicketReceiverServer()
+
+    reactor.listenTCP(port, TicketReceiverServerFactory())
+
+    _LOGGER.info('Running ticket receiver on port: %s', port)
+    reactor.run()

--- a/lib/python/treadmill/websocket/api/app_group.py
+++ b/lib/python/treadmill/websocket/api/app_group.py
@@ -1,0 +1,74 @@
+"""A WebSocket handler for Treadmill app_groups
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import os
+
+from treadmill import schema
+from treadmill import yamlwrapper as yaml
+
+_LOGGER = logging.getLogger(__name__)
+
+
+_TOPIC = '/app-groups'
+_SUB_DIR = '/app-groups'
+
+
+class AppGroupAPI:
+    """Handler for /app-groups topic.
+    """
+
+    def __init__(self):
+        """constructor of API class
+        """
+
+        @schema.schema({'$ref': 'websocket/app_group.json#/message'})
+        def subscribe(message):
+            """Return filter based on message payload.
+            """
+            app_group = message.get('app-group', '*')
+
+            return [(_SUB_DIR, app_group)]
+
+        def on_event(filename, operation, content):
+            """Event handler.
+            """
+            if not filename.startswith('{}/'.format(_SUB_DIR)):
+                return None
+
+            app_group = os.path.basename(filename)
+
+            sow = operation is None
+            message = {
+                'topic': _TOPIC,
+                'app-group': app_group,
+                'sow': sow
+            }
+
+            if content:
+                app_group_data = yaml.load(content)
+                raw_data = app_group_data.pop('data', [])
+                message.update(app_group_data)
+
+                data = {}
+                for kv_str in raw_data:
+                    (key, val) = kv_str.split('=', 1)
+                    data[key] = val
+
+                message['data'] = data
+
+            return message
+
+        self.subscribe = subscribe
+        self.on_event = on_event
+
+
+def init():
+    """API module init.
+    """
+    return [(_TOPIC, AppGroupAPI(), [])]

--- a/lib/python/treadmill/zkctx.py
+++ b/lib/python/treadmill/zkctx.py
@@ -13,10 +13,15 @@ from treadmill import zkutils
 _LOGGER = logging.getLogger(__name__)
 
 
-def connect(zkurl, idpath=None):
+def connect(zkurl, idpath=None, session_timeout=None):
     """Returns connection to Zookeeper.
     """
-    return zkutils.connect(zkurl, idpath=idpath, listener=zkutils.exit_never)
+    return zkutils.connect(
+        zkurl,
+        idpath=idpath,
+        listener=zkutils.exit_never,
+        session_timeout=session_timeout
+    )
 
 
 def resolve(_ctx, attr):

--- a/lib/python/treadmill/zkutils.py
+++ b/lib/python/treadmill/zkutils.py
@@ -180,7 +180,7 @@ def disconnect(zkclient):
 
 def connect(zkurl, idpath=None, listener=None, max_tries=30,
             timeout=ZK_MAX_CONNECTION_START_TIMEOUT, chroot=None,
-            **connargs):
+            session_timeout=None, **connargs):
     """Establish connection with Zk and return KazooClient.
 
     :param max_tries:
@@ -204,6 +204,7 @@ def connect(zkurl, idpath=None, listener=None, max_tries=30,
         listener=listener,
         timeout=timeout, max_tries=max_tries,
         chroot=chroot,
+        session_timeout=session_timeout,
         **connargs
     )
 
@@ -217,7 +218,7 @@ def connect(zkurl, idpath=None, listener=None, max_tries=30,
 
 def connect_native(zkurl, client_id=None, listener=None, max_tries=30,
                    timeout=ZK_MAX_CONNECTION_START_TIMEOUT, chroot=None,
-                   **connargs):
+                   session_timeout=None, **connargs):
     """Establish connection with Zk and return KazooClient.
     """
     _LOGGER.debug('Connecting to %s', zkurl)
@@ -258,6 +259,9 @@ def connect_native(zkurl, client_id=None, listener=None, max_tries=30,
         'command_retry': zk_retry,
         'hosts': hosts,
     })
+
+    if session_timeout is not None:
+        connargs['timeout'] = session_timeout
 
     _LOGGER.debug(
         'Connecting to zookeeper: [%s:%s]: %r',


### PR DESCRIPTION
 * Fix 'treadmill admin krb forward'
 * THAW freezer cgroup when reclaiming the container
 * Fix authorization logging.
 * Add services to all possible cgroups
 * Added nonfwd ticket receiver.
 * Add current identity count when saving placement data for an app with
   identity group, expose it as IDENTITY_COUNT.
 * Warpgate: Enable SO_KEEPALIVE on control channel.
 * net: Exclude TM port ranges from ephemeral range.
 * keytab locker2 support keytab deleting
 * newnet: Fix parent kill race condition
 * Graceful fallback to insecure registry if TLS is not configured
 * Configurable ZK session timeout for node services, can be configured
   for cell/partition/server (by default it's not set resulting in minimum
   session timeout of 20s which equals two ticks).
 * app_event schema allow personal container name pattern
 * Add 'treadmill admin checkout ldap'
 * able to subscribe app group change from websocket API