### PR TITLE
Sync with 2019.05.15-2

### DIFF
--- a/lib/python/treadmill/appcfg/manifest.py
+++ b/lib/python/treadmill/appcfg/manifest.py
@@ -334,6 +334,7 @@ def add_linux_services(manifest):
             'interval': 60,
         },
         'command': (
+            'unset KRB5_KTNAME;unset KRB5CCNAME;'
             'exec {sshd} -D -f /etc/ssh/sshd_config'
             ' -p {sshd_port}'
         ).format(

--- a/lib/python/treadmill/reports.py
+++ b/lib/python/treadmill/reports.py
@@ -294,6 +294,7 @@ class ExplainVisitor:
             'cpu': int(acc_demand[1]),
             'disk': int(acc_demand[2]),
             'name': app.name,
+            'server': app.server,
         })
 
     def finish(self):

--- a/lib/python/treadmill/runtime/linux/_run.py
+++ b/lib/python/treadmill/runtime/linux/_run.py
@@ -89,6 +89,8 @@ def run(tm_env, runtime_config, container_dir, manifest):
         'ip1': app_network['vip'],
     }
 
+    manifest['boot_commands'] = []
+
     # Allocate dynamic ports
     #
     # Ports are taken from ephemeral range, by binding to socket to port 0.

--- a/lib/python/treadmill/runtime/linux/image/native.py
+++ b/lib/python/treadmill/runtime/linux/image/native.py
@@ -22,6 +22,7 @@ from treadmill import runtime
 from treadmill import subproc
 from treadmill import supervisor
 from treadmill import utils
+from treadmill import templates
 
 from treadmill.fs import linux as fs_linux
 
@@ -195,6 +196,15 @@ def create_supervision_tree(tm_env, container_dir, root_dir, app,
             monitor_policy=monitor_policy
         )
     services_scandir.write()
+
+    # Create services startup script.
+    boot_commands = getattr(app, 'boot_commands', [])
+    templates.create_script(
+        os.path.join(container_dir, 'services', 'services.init'),
+        's6.init',
+        boot_commands=boot_commands,
+        _alias=subproc.get_aliases(),
+    )
 
     # Bind the service directory in the container volume
     fs.mkdir_safe(os.path.join(root_dir, 'services'))

--- a/lib/python/treadmill/sproc/start_container.py
+++ b/lib/python/treadmill/sproc/start_container.py
@@ -68,21 +68,6 @@ def init():
         _LOGGER.debug('Current mounts: %s',
                       pprint.pformat(fs_linux.list_mounts()))
 
-        # Clean the environ
-        # TODO: Remove me once clean environment management is merged in.
-        os.environ.pop('PYTHONPATH', None)
-        os.environ.pop('LC_ALL', None)
-        os.environ.pop('LANG', None)
-
-        # Clear aliases path.
-        os.environ.pop('TREADMILL_ALIASES_PATH', None)
-
-        subproc.safe_exec(
-            [
-                's6_svscan',
-                '-s',
-                '/services'
-            ]
-        )
+        subproc.safe_exec(['/services/services.init'])
 
     return start_container

--- a/lib/python/treadmill/subproc.py
+++ b/lib/python/treadmill/subproc.py
@@ -11,7 +11,6 @@ import os
 import functools
 import io
 import json
-import shlex
 
 import six
 
@@ -76,32 +75,7 @@ def get_aliases():
 def _split(command):
     """Split command into parts.
     """
-    # On windows, shlex does not seem to work properly, in particular:
-    #
-    # >>> shlex.split('/x/y/z\\xxx')
-    # >>> ['/x/y/zxxx']
-    #
-    # This is clearly wrong, so on windows just split on whitespace. It is
-    # bad design to have alias with arguments containing whitespace anyway, so
-    # does not seem like critical regression.
-    if os.name == 'nt':
-        return command.split()
-    else:
-        return shlex.split(command)
-
-
-def _quote(arg):
-    """Quote argument to be shell safe.
-    """
-    # On windows, shell.quote adds extra "" as in:
-    #
-    # >>> shlex.quote('\\s\\d')
-    # "'\\s\\d'"
-    if os.name == 'nt':
-        assert len(arg.split()) == 1
-        return arg
-    else:
-        return shlex.quote(arg)
+    return command.split()
 
 
 def _check(path):
@@ -123,7 +97,7 @@ def _normalize(command):
     """Normalize command."""
     split = _split(command)
     split[0] = os.path.normpath(split[0])
-    return ' '.join(_quote(part) for part in split)
+    return ' '.join(split)
 
 
 @functools.lru_cache(maxsize=256)

--- a/lib/python/treadmill/templates/s6.init
+++ b/lib/python/treadmill/templates/s6.init
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+unset PYTHONPATH
+unset LC_ALL
+unset LANG
+unset TREADMILL_ALIASES_PATH
+
+{% for cmd in boot_commands %}
+{{ cmd }}
+{% endfor %}
+
+exec {{ _alias.s6_svscan }} -s /services

--- a/lib/python/treadmill/tests/appcfg/runtime_manifest_test.py
+++ b/lib/python/treadmill/tests/appcfg/runtime_manifest_test.py
@@ -239,6 +239,7 @@ class AppCfgRuntimeManifestTest(unittest.TestCase):
                 },
                 {
                     'command': (
+                        'unset KRB5_KTNAME;unset KRB5CCNAME;'
                         'exec /path/to/sshd'
                         ' -D -f /etc/ssh/sshd_config'
                         ' -p 22'

--- a/lib/python/treadmill/tests/subproc_test.py
+++ b/lib/python/treadmill/tests/subproc_test.py
@@ -29,12 +29,17 @@ class SubprocTest(unittest.TestCase):
         'foo': 'bar',
         'xxx': functools.partial(os.path.join, '/x/y/z'),
         'xxx_d': functools.partial(os.path.join, '/x/y/z')('.'),
+        'lib': '/x/$LIB/lib.so',
     }))
     @mock.patch('treadmill.subproc._check', mock.Mock(return_value=True))
     def test_resolve(self):
         """Test resolve.
         """
         self.assertEqual(subproc.resolve('foo'), 'bar')
+
+        if os.name != 'nt':
+            self.assertEqual(subproc.resolve('lib'), '/x/$LIB/lib.so')
+
         if os.name == 'nt':
             self.assertEqual(subproc.resolve('xxx'), '\\x\\y\\z\\xxx')
             self.assertEqual(subproc.resolve('xxx_d'), '\\x\\y\\z')


### PR DESCRIPTION
 * Do not quote/parse aliases.
 * add server column to admin scheduler explain queue
 * Do not leak environment vars to system services.
 * Implement boot commands.