### PR TITLE
Sync with 2019.05.23-1

### DIFF
--- a/entry_points.txt
+++ b/entry_points.txt
@@ -194,6 +194,7 @@ checkout = treadmill.cli.admin.checkout
 check-aliases = treadmill.cli.admin.check_aliases
 
 [treadmill.cli.admin.install]
+kt-fwd = treadmill.cli.admin.install.kt_fwd
 master = treadmill.cli.admin.install.master
 node = treadmill.cli.admin.install.node
 openldap = treadmill.cli.admin.install.openldap
@@ -290,6 +291,7 @@ monitor = treadmill.cron.model.monitor
 
 [treadmill.bootstrap]
 aliases = treadmill.bootstrap.aliases
+kt-fwd = treadmill.bootstrap.kt_fwd
 master = treadmill.bootstrap.master
 node = treadmill.bootstrap.node
 openldap = treadmill.bootstrap.openldap

--- a/lib/python/treadmill/ad/_servers.py
+++ b/lib/python/treadmill/ad/_servers.py
@@ -46,6 +46,7 @@ def create_ldap_connection(domain_controller):
         server,
         authentication=ldap3.SASL,
         sasl_mechanism='GSSAPI',
+        sasl_credentials=(True,),
         client_strategy=ldap3.RESTARTABLE,
         auto_bind=True,
         auto_range=True,

--- a/lib/python/treadmill/admin/_ldap.py
+++ b/lib/python/treadmill/admin/_ldap.py
@@ -540,7 +540,8 @@ class Admin:
             else:
                 ldap_auth = {
                     'authentication': ldap3.SASL,
-                    'sasl_mechanism': 'GSSAPI'
+                    'sasl_mechanism': 'GSSAPI',
+                    'sasl_credentials': (True,)
                 }
 
             return ldap3.Connection(

--- a/lib/python/treadmill/api/allocation.py
+++ b/lib/python/treadmill/api/allocation.py
@@ -86,7 +86,7 @@ def _check_capacity(cell, allocation, rsrc):
     limits = [
         limit
         for limit in part_obj['limits']
-        if limit['trait'] in rsrc['traits']
+        if limit['trait'] in rsrc.get('traits', [])
     ]
 
     # check trait based allocation limits

--- a/lib/python/treadmill/api/app_dns.py
+++ b/lib/python/treadmill/api/app_dns.py
@@ -29,6 +29,7 @@ def _group2dns(app_group):
 
     app_dns['alias'] = None
     app_dns['scope'] = None
+    app_dns['identity-group'] = None
 
     if data:
         data_dict = data
@@ -39,6 +40,8 @@ def _group2dns(app_group):
             app_dns['alias'] = data_dict.get('alias')
         if data_dict.get('scope'):
             app_dns['scope'] = data_dict.get('scope')
+        if data_dict.get('identity-group'):
+            app_dns['identity-group'] = data_dict.get('identity-group')
 
     return app_dns
 
@@ -49,6 +52,7 @@ def _dns2group(app_dns):
     app_group['group-type'] = 'dns'
     alias = app_group.get('alias')
     scope = app_group.get('scope')
+    id_group = app_group.get('identity-group')
     if not alias:
         return app_group
 
@@ -57,9 +61,16 @@ def _dns2group(app_dns):
         app_group['data'].append('alias={0}'.format(alias))
     if scope:
         app_group['data'].append('scope={0}'.format(scope))
+    if id_group:
+        app_group['data'].append('identity-group={0}'.format(id_group))
 
-    del app_group['alias']
-    del app_group['scope']
+    try:
+        del app_group['alias']
+        del app_group['scope']
+        del app_group['identity-group']
+    except KeyError:
+        pass
+
     if not app_group['data']:
         del app_group['data']
 

--- a/lib/python/treadmill/api/model/app.py
+++ b/lib/python/treadmill/api/model/app.py
@@ -48,6 +48,7 @@ def models(api):
         'rules': fields.List(fields.Nested(vring_rule)),
     })
     affinity_limits = api.model('AffinityLimit', {
+        'bunker': fields.Integer(description='Bunker'),
         'pod': fields.Integer(description='Pod'),
         'rack': fields.Integer(description='Rack'),
         'server': fields.Integer(description='Server'),

--- a/lib/python/treadmill/appcfg/abort.py
+++ b/lib/python/treadmill/appcfg/abort.py
@@ -34,6 +34,7 @@ class AbortedReason(enum.Enum):
     UNKNOWN = 'unknown'
     UNSUPPORTED = 'unsupported'
     INVALID_TYPE = 'invalid_type'
+    KEYTABS = 'keytabs'
     TICKETS = 'tickets'
     SCHEDULER = 'scheduler'
     PORTS = 'ports'
@@ -49,6 +50,7 @@ class AbortedReason(enum.Enum):
         """Gets the description for the current aborted reason."""
         return {
             AbortedReason.INVALID_TYPE: 'invalid image type',
+            AbortedReason.KEYTABS: 'keytabs could not be fetched',
             AbortedReason.TICKETS: 'tickets could not be fetched',
             AbortedReason.SCHEDULER: 'scheduler error',
             AbortedReason.PORTS: 'ports could not be assigned',

--- a/lib/python/treadmill/appcfg/manifest.py
+++ b/lib/python/treadmill/appcfg/manifest.py
@@ -227,12 +227,14 @@ def add_linux_system_services(tm_env, manifest):
             ' --cell {cell}'
             ' presence register'
             ' {manifest} {container_dir}'
+            ' --kt-locker-pattern {treadmill_id}.keytabs-locker-v2'
         ).format(
             treadmill=subproc.resolve('treadmill'),
             zkurl=manifest['zookeeper'],
             cell=manifest['cell'],
             manifest=os.path.join(container_data_dir, 'state.json'),
-            container_dir=container_data_dir
+            container_dir=container_data_dir,
+            treadmill_id=os.environ['TREADMILL_ID'],
         ),
         'environ': [
             {

--- a/lib/python/treadmill/bootstrap/kt_fwd/__init__.py
+++ b/lib/python/treadmill/bootstrap/kt_fwd/__init__.py
@@ -1,0 +1,11 @@
+"""Treadmill keytab forwarder bootstrap.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from .. import aliases
+
+ALIASES = aliases.ALIASES

--- a/lib/python/treadmill/cli/admin/install/kt_fwd.py
+++ b/lib/python/treadmill/cli/admin/install/kt_fwd.py
@@ -1,0 +1,45 @@
+"""Installs and configures Treadmill keytab fwd locally.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import logging
+
+import click
+
+from treadmill.bootstrap import install as bs_install
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def init():
+    """Return top level command handler.
+    """
+
+    @click.command(name='kt-fwd')
+    @click.option('--run/--no-run', is_flag=True, default=False)
+    @click.pass_context
+    def kt_fwd(ctx, run):
+        """Installs Treadmill keytab fwd server.
+        """
+        dst_dir = ctx.obj['PARAMS']['dir']
+        profile = ctx.obj['PARAMS'].get('profile')
+
+        run_script = None
+        if run:
+            run_script = os.path.join(dst_dir, 'bin', 'run.sh')
+
+        bs_install.install(
+            'kt-fwd',
+            dst_dir,
+            ctx.obj['PARAMS'],
+            run=run_script,
+            profile=profile,
+        )
+
+    return kt_fwd

--- a/lib/python/treadmill/cli/app_dns.py
+++ b/lib/python/treadmill/cli/app_dns.py
@@ -28,17 +28,7 @@ def init():
         """Manage Treadmill App DNS configuration.
         """
 
-    @appdns.command()
-    @click.argument('name', nargs=1, required=True)
-    @click.option('--cell', help='List of cells',
-                  type=cli.LIST)
-    @click.option('--pattern', help='App pattern')
-    @click.option('--endpoints', help='Endpoints to be included in SRV rec',
-                  type=cli.LIST)
-    @click.option('--alias', help='App DNS alias')
-    @click.option('--scope', help='DNS scope')
-    @cli.handle_exceptions(restclient.CLI_REST_EXCEPTIONS)
-    def configure(name, cell, pattern, endpoints, alias, scope):
+    def configure_base(name, cell, pattern, endpoints, alias, scope, id_group):
         """Create, modify or get Treadmill App DNS entry"""
         restapi = context.GLOBAL.admin_api()
         url = _REST_PATH + name
@@ -54,6 +44,8 @@ def init():
             data['alias'] = alias
         if scope is not None:
             data['scope'] = scope
+        if id_group is not None:
+            data['identity-group'] = id_group
 
         if data:
             try:
@@ -67,6 +59,58 @@ def init():
         app_dns_entry = restclient.get(restapi, url).json()
 
         cli.out(formatter(app_dns_entry))
+
+    @appdns.command()
+    @click.argument('name', nargs=1, required=True)
+    @click.option('--cell', help='List of cells',
+                  type=cli.LIST)
+    @click.option('--pattern', help='App pattern')
+    @click.option('--endpoints', help='Endpoints to be included in SRV rec',
+                  type=cli.LIST)
+    @click.option('--alias', help='App DNS alias')
+    @click.option('--scope', help='DNS scope')
+    @cli.handle_exceptions(restclient.CLI_REST_EXCEPTIONS)
+    def configure(name, cell, pattern, endpoints, alias, scope):
+        """Create, modify or get DNS SRV entry"""
+        configure_base(name, cell, pattern, endpoints, alias, scope, None)
+
+    @appdns.group(name='cname')
+    def cname():
+        """Manage DNS CNAME configuration.
+        """
+
+    @cname.command(name='configure')
+    @click.argument('name', nargs=1, required=True)
+    @click.option('--cell', help='List of cells',
+                  type=cli.LIST)
+    @click.option('--pattern', help='App pattern')
+    @click.option('--alias', help='App DNS alias')
+    @click.option('--scope', help='DNS scope')
+    @click.option('--identity-group', 'id_group', help='Identity group to '
+                  'create alias(es) pointing to the instances\' hosts')
+    @cli.handle_exceptions(restclient.CLI_REST_EXCEPTIONS)
+    def configure_cname(name, cell, pattern, alias, scope, id_group):
+        """Create, modify or get DNS CNAME configuration"""
+        configure_base(name, cell, pattern, None, alias, scope, id_group)
+
+    @appdns.group(name='srv')
+    def srv():
+        """Manage DNS SRV configuration.
+        """
+
+    @srv.command(name='configure')
+    @click.argument('name', nargs=1, required=True)
+    @click.option('--cell', help='List of cells',
+                  type=cli.LIST)
+    @click.option('--pattern', help='App pattern')
+    @click.option('--endpoints', help='Endpoints to be included in SRV rec',
+                  type=cli.LIST)
+    @click.option('--alias', help='App DNS alias')
+    @click.option('--scope', help='DNS scope')
+    @cli.handle_exceptions(restclient.CLI_REST_EXCEPTIONS)
+    def configure_srv(name, cell, pattern, endpoints, alias, scope):
+        """Create, modify or get DNS SRV entry"""
+        configure_base(name, cell, pattern, endpoints, alias, scope, None)
 
     @appdns.command()
     @click.argument('name', nargs=1, required=True)
@@ -112,5 +156,9 @@ def init():
     del cells
     del _list
     del configure
+    del configure_cname
+    del configure_srv
+    del cname
+    del srv
 
     return appdns

--- a/lib/python/treadmill/etc/schema/app.json
+++ b/lib/python/treadmill/etc/schema/app.json
@@ -191,6 +191,7 @@
                 "type" : "object",
                 "additionalProperties" : false,
                 "properties": {
+                    "bunker": { "$ref": "#/limit" },
                     "pod": { "$ref": "#/limit" },
                     "rack": { "$ref": "#/limit" },
                     "server": { "$ref": "#/limit" },

--- a/lib/python/treadmill/etc/schema/app_dns.json
+++ b/lib/python/treadmill/etc/schema/app_dns.json
@@ -26,7 +26,8 @@
             "scope": {
                 "type": "string",
                 "pattern": "^cell$|^campus$|^region$|^global$"
-            }
+            },
+            "identity-group": { "$ref": "common.json#/identity_group_id" }
         }
     },
     "verbs": {

--- a/lib/python/treadmill/formatter/tablefmt.py
+++ b/lib/python/treadmill/formatter/tablefmt.py
@@ -196,6 +196,7 @@ class AppPrettyFormatter:
         ])
 
         affinity_limits_tbl = make_dict_to_table([
+            ('bunker', None, None),
             ('pod', None, None),
             ('rack', None, None),
             ('server', None, None),
@@ -685,12 +686,15 @@ class AppDNSPrettyFormatter:
     @staticmethod
     def format(item):
         """Return pretty-formatted item."""
-        schema = [('name', '_id', None),
-                  ('scope', None, None),
-                  ('cells', None, None),
-                  ('pattern', None, None),
-                  ('endpoints', None, None),
-                  ('alias', None, None)]
+        schema = [
+            ('name', '_id', None),
+            ('scope', None, None),
+            ('cells', None, None),
+            ('pattern', None, None),
+            ('endpoints', None, None),
+            ('alias', None, None),
+            ('identity-group', None, None),
+        ]
 
         format_item = make_dict_to_table(schema)
         format_list = make_list_to_table(schema)

--- a/lib/python/treadmill/keytabs2/locker.py
+++ b/lib/python/treadmill/keytabs2/locker.py
@@ -1,0 +1,222 @@
+"""
+locker class of keytabs2 implementation
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import os
+import re
+import socket
+import sqlite3
+
+import kazoo
+import kazoo.client
+
+from treadmill import keytabs2
+from treadmill import zknamespace as z
+from treadmill import zkutils
+from treadmill.gssapiprotocol import jsonserver
+
+_LOGGER = logging.getLogger(__name__)
+
+_KEYTAB_PATTERN = r'\w+#(.+)@.+'
+_KEYTAB_RE_OBJ = re.compile(_KEYTAB_PATTERN)
+
+
+def _translate_vip(keytab):
+    """Get ip address from hostname inside keytab string
+    """
+    match = _KEYTAB_RE_OBJ.match(keytab)
+    if match:
+        hostname = match.group(1)
+    else:
+        raise keytabs2.KeytabLockerError(
+            'Keytab {} in wrong format'.format(keytab)
+        )
+
+    _LOGGER.debug('Trying to get vip of %s', hostname)
+    ipaddress = socket.gethostbyname(hostname)
+    _LOGGER.info('keytab => vip: %s => %s', keytab, ipaddress)
+    return ipaddress
+
+
+class KeytabLocker:
+    """Keytab Locker to provide keytabs to requesting apps
+    """
+
+    def __init__(self, kt_spool_dir, database, zkclient):
+        """KeytabLocker constructor.
+
+        :param kt_spool_dir: Path to store keytab files.
+        :param database: Path to SQLite3 db file which stores VIP keytab/proid
+                         relationships
+        """
+        self.zkclient = zkclient
+        self.zkclient.add_listener(zkutils.exit_on_lost)
+        self._kt_spool_dir = kt_spool_dir
+        self._database = database
+
+    def get(self, princ, app_name):
+        """Get keytabs defined in manifest from locker.
+        returns:
+            list -- encoded keytab contents required by app
+        """
+        keytab_names = self.query(princ, app_name)
+
+        try:
+            keytabs = {
+                keytab: keytabs2.read_keytab(
+                    os.path.join(self._kt_spool_dir, keytab)
+                )
+                for keytab in keytab_names
+            }
+        except OSError as err:
+            raise keytabs.KeytabLockerError(err)
+
+        return keytabs
+
+    def query(self, princ, app_name):
+        """query if keytabs are valid in manifest
+        returns:
+            list -- keytab names required by app
+        """
+        vips = self._query_proid_vips(app_name)
+        keytabs = self._get_app_keytabs(princ, app_name)
+
+        for keytab in keytabs:
+            vip = _translate_vip(keytab)
+
+            if vip not in vips:
+                raise keytabs2.KeytabLockerError(
+                    '{} of keytab {} does not exist or of wrong proid'.format(
+                        vip, keytab)
+                )
+        return keytabs
+
+    def _query_proid_vips(self, appname):
+        """query proid vips relationship
+        """
+        proid = appname.split('.')[0]
+
+        res = set()
+        if not os.path.exists(self._database):
+            _LOGGER.error('DB %s not exist', self._database)
+            raise keytabs2.KeytabLockerError('DB not exist')
+
+        conn = sqlite3.connect(self._database)
+        cur = conn.cursor()
+        try:
+            query = 'SELECT vip FROM {} where proid = ?'.format(keytabs2.TABLE)
+            store_virtuals = cur.execute(query, (proid,)).fetchall()
+            res = set([virtual[0] for virtual in store_virtuals])
+        except sqlite3.OperationalError as err:
+            # table may not exist yet, try sync in the next execution
+            _LOGGER.warning('wait for keytab locker starting.')
+        finally:
+            conn.close()
+        return res
+
+    def _get_app_keytabs(self, princ, appname):
+        """Get keytabs required for the given app."""
+        # TODO: the logic is duplicated with ticket locker
+        # we need to refactor to implement generic locker in the future
+        if not princ or not princ.startswith('host/'):
+            raise keytabs2.KeytabLockerError(
+                'princ "{}" not accepted'.format(princ)
+            )
+
+        hostname = princ[len('host/'):princ.rfind('@')]
+
+        if not self.zkclient.exists(z.path.placement(hostname, appname)):
+            _LOGGER.error('App %s not scheduled on node %s', appname, hostname)
+            return []
+
+        try:
+            appnode = z.path.scheduled(appname)
+            app = zkutils.with_retry(zkutils.get, self.zkclient, appnode)
+
+            return app.get('keytabs', [])
+        except kazoo.client.NoNodeError:
+            _LOGGER.info('App does not exist: %s', appname)
+            return []
+
+
+def get_locker_server(locker, port):
+    """Build keytab server protocol.
+    """
+    from twisted.internet import protocol
+    from twisted.internet import reactor
+
+    def _response(success=False, message=None, keytabs=None):
+        """Construct response."""
+        return {
+            'success': success,
+            'message': message,
+            'keytabs': keytabs,
+        }
+
+    class _KeytabLockerServerProtocol(jsonserver.GSSAPIJsonServer):
+        """Implement keytab receiver server protocol."""
+
+        def _get(self, req):
+            """get keytabs from appname
+            """
+            try:
+                app_name = req['app']
+            except KeyError:
+                raise keytabs2.KeytabLockerError('No "app" in request')
+            keytabs = locker.get(self.peer(), app_name)
+            return _response(success=True, keytabs=keytabs)
+
+        def _query(self, req):
+            """query keytabs from appname
+            """
+            try:
+                app_name = req['app']
+            except KeyError:
+                raise keytabs2.KeytabLockerError('No "app" in request')
+
+            locker.query(self.peer(), app_name)
+            return _response(success=True)
+
+        def on_request(self, request):
+            """Process keytab requests."""
+            action = request.get('action')
+            try:
+                if action == 'get':
+                    return self._get(request)
+                elif action == 'query':
+                    return self._query(request)
+                else:
+                    return _response(success=False, message='Unknown Action')
+
+            except keytabs2.KeytabLockerError as err:
+                _LOGGER.error(err.message)
+                return _response(success=False, message=err.message)
+
+    class _KeytabLockerServer:
+        """Keytab receiver server."""
+
+        def __init__(self):
+            """_KeytabLockerServer constructor."""
+            factory = protocol.Factory.forProtocol(
+                _KeytabLockerServerProtocol
+            )
+            listening_port = reactor.listenTCP(port, factory)
+
+            def _get_actual_port():
+                """Get actual listening port."""
+                return listening_port.getHost().port
+
+            def _run():
+                """Start keytab locker server"""
+                reactor.run()
+
+            self.get_actual_port = _get_actual_port
+            self.run = _run
+
+    return _KeytabLockerServer()

--- a/lib/python/treadmill/keytabs2/receiver.py
+++ b/lib/python/treadmill/keytabs2/receiver.py
@@ -54,7 +54,7 @@ class KeytabReceiver:
     __slot__ = ['_kt_spool_dir', '_database', '_owner']
 
     def __init__(self, kt_spool_dir, database, owner):
-        """KeytabLocker constructor.
+        """KeytabReceiver constructor.
 
         :param kt_spool_dir: Path to store keytab files.
         :param database: Path to SQLite3 db file which stores VIP keytab/proid

--- a/lib/python/treadmill/rest/api/app_dns.py
+++ b/lib/python/treadmill/rest/api/app_dns.py
@@ -27,6 +27,8 @@ def init(api, cors, impl):
         'endpoints': fields.List(fields.String(description='Endpoints')),
         'alias': fields.String(description='Alias'),
         'scope': fields.String(description='Scope', required=True),
+        'identity-group': fields.String(description='Identity gruop id',
+                                        required=False),
     }
 
     app_dns_model = api.model(

--- a/lib/python/treadmill/runtime/linux/image/native.py
+++ b/lib/python/treadmill/runtime/linux/image/native.py
@@ -504,11 +504,11 @@ def _prepare_krb(tm_env, container_dir, root_dir, app):
     keytabs.make_keytab(kt_dest, kt_sources)
 
     for kt_spec in app.keytabs:
-        if ':' in kt_spec:
-            owner, princ = kt_spec.split(':', 1)
-        else:
-            owner = kt_spec
-            princ = kt_spec
+        if ':' not in kt_spec:
+            # if ':' not in spec we tried to fetch from keytab locker
+            continue
+
+        owner, princ = kt_spec.split(':', 1)
 
         kt_dest = os.path.join(root_dir, 'var', 'spool', 'keytabs', owner)
         kt_sources = glob.glob(os.path.join(tm_env.spool_dir, 'keytabs',

--- a/lib/python/treadmill/tests/api/allocation_test.py
+++ b/lib/python/treadmill/tests/api/allocation_test.py
@@ -129,6 +129,26 @@ class ApiAllocationTest(unittest.TestCase):
              'memory': '10G'},
         )
 
+        # make sure capacity checking works without specifing traits
+        # in reservation request
+        self.alloc_api.reservation.create(
+            'tenant/alloc/cellname',
+            {
+                'cpu': '100%',
+                'memory': '10G',
+                'disk': '10G',
+                'partition': 'ppp',
+            }
+        )
+        alloc_admin.create.assert_called_with(
+            ['cellname', 'tenant/alloc'],
+            {'disk': '10G',
+             'partition': 'ppp',
+             'cpu': '100%',
+             'rank': 100,
+             'memory': '10G'},
+        )
+
         # let's add a reservation so we don't have anough free
         # capacity anymore
         alloc_admin.list.return_value = [

--- a/lib/python/treadmill/tests/api/app_dns_test.py
+++ b/lib/python/treadmill/tests/api/app_dns_test.py
@@ -32,15 +32,52 @@ class AppDnsTest(unittest.TestCase):
         self.assertEqual(
             app_dns._group2dns(group),
             {'pattern': 'xxx.yyy', 'cells': ['cell1'],
-             'alias': None, 'scope': None}
+             'alias': None, 'scope': None, 'identity-group': None}
         )
+        # TODO
+        # self.assertEqual(app_dns._dns2group(app_dns._group2dns(group)),
+        #                  group)
 
-        group['data'] = ['alias=foo', 'scope=region']
+        group['data'] = ['alias=foo', 'scope=region', 'identity-group=bar']
         self.assertEqual(
             app_dns._group2dns(group),
             {'pattern': 'xxx.yyy', 'cells': ['cell1'],
-             'alias': 'foo', 'scope': 'region'}
+             'alias': 'foo', 'scope': 'region', 'identity-group': 'bar'}
         )
+        # TODO
+        # self.assertEqual(app_dns._dns2group(app_dns._group2dns(group)),
+        #                  group)
+
+    def test_dns2group(self):
+        """Tests app-dns to app-group conversion."""
+        # Disable W0212: accessing protected members.
+        # pylint: disable=W0212
+
+        dns = {'pattern': 'xxx.yyy*', 'alias': 'x.alias', 'scope': 'cell'}
+        self.assertEqual(
+            app_dns._dns2group(dns), {
+                'pattern': 'xxx.yyy*',
+                'data': ['alias=x.alias', 'scope=cell'],
+                'group-type': 'dns'
+            })
+
+        dns = {
+            'pattern': 'xxx.yyy*',
+            'cells': ['cell1'],
+            'alias': 'x.alias',
+            'scope': 'cell',
+            'identity-group': 'x.id-group',
+            'endpoints': ['http']
+        }
+        self.assertEqual(
+            app_dns._dns2group(dns), {
+                'cells': ['cell1'],
+                'data': ['alias=x.alias', 'scope=cell',
+                         'identity-group=x.id-group'],
+                'endpoints': ['http'],
+                'group-type': 'dns',
+                'pattern': 'xxx.yyy*'
+            })
 
 
 if __name__ == '__main__':

--- a/lib/python/treadmill/tests/api/authz/group_test.py
+++ b/lib/python/treadmill/tests/api/authz/group_test.py
@@ -32,8 +32,47 @@ class GroupAuthzTest(unittest.TestCase):
     def test_authorize(self, mock_getgrnam):
         """Dummy test for treadmill.api.cell.get()"""
         # set templates directly.
-        grp_authz = group.API(groups=['treadmill.{proid}'])
+        grp_authz = group.API(
+            groups=['treadmill.{proid}'],
+            exclude=['*:get', '*:list', 'r2:create']
+        )
         mock_getgrnam.return_value = _MockGrp(['u1'])
+
+        authorized, _ = grp_authz.authorize(
+            'u1@realm', 'get', 'r1', {'pk': 'proidX.a'}
+        )
+        self.assertTrue(authorized)
+        mock_getgrnam.assert_not_called()
+
+        authorized, _ = grp_authz.authorize(
+            'u2@realm', 'get', 'r1', {'pk': 'proidX.a'}
+        )
+        self.assertTrue(authorized)
+        mock_getgrnam.assert_not_called()
+
+        authorized, _ = grp_authz.authorize(
+            'u1@realm', 'list', 'r1', {}
+        )
+        self.assertTrue(authorized)
+        mock_getgrnam.assert_not_called()
+
+        authorized, _ = grp_authz.authorize(
+            'u2@realm', 'list', 'r1', {}
+        )
+        self.assertTrue(authorized)
+        mock_getgrnam.assert_not_called()
+
+        authorized, _ = grp_authz.authorize(
+            'u1@realm', 'create', 'r2', {'pk': 'proidX.a'}
+        )
+        self.assertTrue(authorized)
+        mock_getgrnam.assert_not_called()
+
+        authorized, _ = grp_authz.authorize(
+            'u2@realm', 'create', 'r2', {'pk': 'proidX.a'}
+        )
+        self.assertTrue(authorized)
+        mock_getgrnam.assert_not_called()
 
         authorized, _ = grp_authz.authorize(
             'u1@realm', 'create', 'r1', {'pk': 'proidX.a'}

--- a/lib/python/treadmill/tests/netutils_test.py
+++ b/lib/python/treadmill/tests/netutils_test.py
@@ -19,7 +19,7 @@ class NetutilsTest(unittest.TestCase):
     """Tests for teadmill.netutils
     """
 
-    def test_netstat_listen_0_0_0_0(self):
+    def test_netstat_listen(self):
         """Tests netutils.netstat"""
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.bind(('0.0.0.0', 0))
@@ -29,7 +29,17 @@ class NetutilsTest(unittest.TestCase):
         self.assertIn(port, netutils.netstat(os.getpid()))
         sock.close()
 
-    def test_netstat_listen_127_0_0_1(self):
+    def test_netstat_listen6(self):
+        """Tests netutils.netstat"""
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        sock.bind(('::0', 0))
+        sock.listen(1)
+        port = sock.getsockname()[1]
+
+        self.assertIn(port, netutils.netstat(os.getpid()))
+        sock.close()
+
+    def test_netstat_listen_loopback(self):
         """Tests netutils.netstat"""
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.bind(('127.0.0.1', 0))
@@ -37,6 +47,17 @@ class NetutilsTest(unittest.TestCase):
         port = sock.getsockname()[1]
 
         # Do not report ports listening on 127.0.0.1
+        self.assertNotIn(port, netutils.netstat(os.getpid()))
+        sock.close()
+
+    def test_netstat_listen_loopback6(self):
+        """Tests netutils.netstat"""
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        sock.bind(('::1', 0))
+        sock.listen(1)
+        port = sock.getsockname()[1]
+
+        # Do not report ports listening on loopback.
         self.assertNotIn(port, netutils.netstat(os.getpid()))
         sock.close()
 

--- a/lib/python/treadmill/tests/tickets_test.py
+++ b/lib/python/treadmill/tests/tickets_test.py
@@ -172,6 +172,8 @@ class TicketLockerTest(unittest.TestCase):
     @mock.patch('treadmill.fs.rm_safe', mock.Mock(spec_set=True))
     @mock.patch('treadmill.tickets.krbcc_ok',
                 mock.Mock(spec_set=True, return_value=True))
+    @mock.patch('treadmill.tickets.kinit_renew',
+                mock.Mock(spec_set=True))
     def test_ticket_write(self):
         """Tests writing ticket to the file system.
         """


### PR DESCRIPTION
 * Fix loading discovery state serialized as json.
 * Include tcp6 when publishing endpoint state.
 * bring back cli doc
 * document reorg
 * ldap3: Only monkeypatch SASL on Windows
 * fix trait capacity checking
 * Do not fetch keytab from keytab locker if keytab is 'proid:service'
 * Group based authorization API - support patterns in the exclusion whitelist.
 * Set 'sasl_credentials': (True,) on ldap3 connection.
 * Fix for containers aborting due to disappearing tickets.
 * App-dns: added identity group.
 * add unit tests cases and schema change for bunker in server topology
 * Add keytab locker on master
 * Add function to install keytab forwarder