### PR TITLE
Sync with 2019.06.10-1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 # bootstrap files
+recursive-include lib/python/treadmill/bootstrap/kt_fwd/linux *
 recursive-include lib/python/treadmill/bootstrap/master/linux *
 recursive-include lib/python/treadmill/bootstrap/node/linux *
 recursive-include lib/python/treadmill/bootstrap/node/windows *

--- a/lib/python/treadmill/api/app.py
+++ b/lib/python/treadmill/api/app.py
@@ -89,6 +89,20 @@ class API:
             _admin_app().replace(rsrc_id, rsrc)
             return _admin_app().get(rsrc_id, dirty=True)
 
+        @schema.schema(
+            {'$ref': 'app.json#/resource_id'},
+            {'allOf': [{'$ref': 'app.json#/resource'},
+                       {'$ref': 'app.json#/verbs/patch'}]}
+        )
+        def patch(rsrc_id, rsrc):
+            """Patch application configuration."""
+            stored_rsrc = _admin_app().get(rsrc_id)
+            verify_feature(rsrc.get('features', []))
+
+            stored_rsrc.update(rsrc)
+            _admin_app().replace(rsrc_id, stored_rsrc)
+            return stored_rsrc
+
         @schema.schema({'$ref': 'app.json#/resource_id'})
         def delete(rsrc_id):
             """Delete configured application."""
@@ -98,4 +112,5 @@ class API:
         self.get = get
         self.create = create
         self.update = update
+        self.patch = patch
         self.delete = delete

--- a/lib/python/treadmill/bootstrap/aliases.py
+++ b/lib/python/treadmill/bootstrap/aliases.py
@@ -112,6 +112,7 @@ _LINUX_ALIASES = {
 
     # s6 root dir.
     's6': None,
+    's6_distro': None,
 
     # s6 utilities
     'backtick': _s6,
@@ -126,6 +127,7 @@ _LINUX_ALIASES = {
     'forbacktickx': _s6,
     'foreground': _s6,
     'forstdin': _s6,
+    'getpid': _s6,
     'heredoc': _s6,
     'if': _s6,
     'ifelse': _s6,
@@ -196,8 +198,8 @@ _WINDOWS_ALIASES = {
     'winss_svscan': None,
     'winss_svscanctl': None,
     'winss_svwait': None,
-    'powershell': 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\'
-                  'powershell.exe',
+    'powershell': ('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\'
+                   'powershell.exe'),
 }
 
 if os.name == 'nt':

--- a/lib/python/treadmill/deprecated.py
+++ b/lib/python/treadmill/deprecated.py
@@ -1,0 +1,46 @@
+"""Deprecation tools
+"""
+
+import functools
+import inspect
+import warnings
+
+
+def deprecated(why):
+    """This is a decorator which can be used to mark functions
+    as deprecated.
+
+    .. code-block:: python
+
+    >>> from treadmill import deprecated
+    >>> @deprecated.deprecated('why, something useful')
+    ... def deprecated_function(x, y):
+    ...     pass
+    """
+
+    def decorator(wrapped):
+        """Decorate a `wrapped` function.
+        """
+
+        if inspect.isclass(wrapped):
+            fmt = 'Call to deprecated class {name!r} ({why}).'
+        else:
+            fmt = 'Call to deprecated function {name!r} ({why}).'
+        message = fmt.format(name=wrapped.__name__, why=why)
+
+        @functools.wraps(wrapped)
+        def wrapper(*args, **kwargs):
+            """Wrapper for deprecated function.
+            NOTE: Docstring get replaced by `functools.wraps`.
+            """
+            warnings.warn(message, category=DeprecationWarning, stacklevel=2)
+            return wrapped(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = (
+    'deprecated',
+)

--- a/lib/python/treadmill/etc/schema/app.json
+++ b/lib/python/treadmill/etc/schema/app.json
@@ -222,6 +222,9 @@
         },
         "update": {
             "required": []
+        },
+        "patch": {
+            "required": []
         }
     }
 }

--- a/lib/python/treadmill/fs/__init__.py
+++ b/lib/python/treadmill/fs/__init__.py
@@ -111,6 +111,7 @@ def write_safe(filename, func, mode='wb', prefix='tmp', subdir=None,
         if err.errno != errno.EEXIST:
             raise
     try:
+        tmpfile = None
         with tempfile.NamedTemporaryFile(dir=dirname,
                                          delete=False,
                                          prefix=prefix,
@@ -136,7 +137,8 @@ def write_safe(filename, func, mode='wb', prefix='tmp', subdir=None,
         replace(tmpfile.name, filename)
 
     finally:
-        rm_safe(tmpfile.name)
+        if tmpfile is not None:
+            rm_safe(tmpfile.name)
 
 
 def mkdir_safe(path, mode=0o777):

--- a/lib/python/treadmill/rest/api/app.py
+++ b/lib/python/treadmill/rest/api/app.py
@@ -68,6 +68,13 @@ def init(api, cors, impl):
             """Updates Treadmill application configuration."""
             return impl.update(app, flask.request.json)
 
+        @webutils.put_api(api, cors,
+                          req_model=request_model,
+                          resp_model=response_model)
+        def patch(self, app):
+            """Updates Treadmill application configuration."""
+            return impl.patch(app, flask.request.json)
+
         @webutils.delete_api(api, cors)
         def delete(self, app):
             """Deletes Treadmill application."""

--- a/lib/python/treadmill/runtime/linux/_run.py
+++ b/lib/python/treadmill/runtime/linux/_run.py
@@ -90,6 +90,7 @@ def run(tm_env, runtime_config, container_dir, manifest):
     }
 
     manifest['boot_commands'] = []
+    manifest['finish_commands'] = []
 
     # Allocate dynamic ports
     #
@@ -150,7 +151,8 @@ def run(tm_env, runtime_config, container_dir, manifest):
         ],
         propagation='slave',
         # We need to keep our mapped ports open
-        close_fds=False
+        close_fds=False,
+        close_child_fds=True
     )
 
 

--- a/lib/python/treadmill/runtime/linux/image/native.py
+++ b/lib/python/treadmill/runtime/linux/image/native.py
@@ -146,9 +146,11 @@ def create_supervision_tree(tm_env, container_dir, root_dir, app,
     sys_scandir.write()
 
     services_dir = os.path.join(container_dir, 'services')
+    finish_commands = getattr(app, 'finish_commands', [])
     services_scandir = supervisor.create_scan_dir(
         services_dir,
-        finish_timeout=5000
+        finish_timeout=5000,
+        finish_commands=finish_commands
     )
 
     for svc_def in app.services:
@@ -200,7 +202,7 @@ def create_supervision_tree(tm_env, container_dir, root_dir, app,
     # Create services startup script.
     boot_commands = getattr(app, 'boot_commands', [])
     templates.create_script(
-        os.path.join(container_dir, 'services', 'services.init'),
+        os.path.join(container_dir, 'services', '.services.init'),
         's6.init',
         boot_commands=boot_commands,
         _alias=subproc.get_aliases(),

--- a/lib/python/treadmill/sproc/start_container.py
+++ b/lib/python/treadmill/sproc/start_container.py
@@ -129,6 +129,6 @@ def init():
         _LOGGER.debug('Current mounts: %s',
                       pprint.pformat(fs_linux.list_mounts()))
 
-        subproc.safe_exec(['/services/services.init'])
+        subproc.safe_exec(['/services/.services.init'])
 
     return start_container

--- a/lib/python/treadmill/supervisor/__init__.py
+++ b/lib/python/treadmill/supervisor/__init__.py
@@ -130,7 +130,9 @@ def open_service(service_dir, existing=True):
 # pylint: disable=W0613
 def _create_scan_dir_s6(scan_dir, finish_timeout,
                         wait_cgroups=None,
-                        kill_svc=None, **kwargs):
+                        kill_svc=None,
+                        finish_commands=None,
+                        **kwargs):
     """Create a scan directory.
 
     :param ``str`` scan_dir:
@@ -147,10 +149,14 @@ def _create_scan_dir_s6(scan_dir, finish_timeout,
     if not isinstance(scan_dir, sup_impl.ScanDir):
         scan_dir = sup_impl.ScanDir(scan_dir)
 
+    if not finish_commands:
+        finish_commands = []
+
     svscan_finish_script = templates.generate_template(
         's6.svscan.finish',
         timeout=finish_timeout,
         wait_cgroups=wait_cgroups,
+        finish_commands=finish_commands,
         _alias=subproc.get_aliases()
     )
     scan_dir.finish = svscan_finish_script

--- a/lib/python/treadmill/templates/s6.svscan.finish
+++ b/lib/python/treadmill/templates/s6.svscan.finish
@@ -97,6 +97,12 @@
 }
 {%- endif %}
 
+{% for cmd in finish_commands %}
+{{ _alias.foreground }} {
+    {{ cmd }}
+}
+{% endfor %}
+
 {{ _alias.foreground }} {
     {{ _alias.echo }} "All services are finished"
 }

--- a/lib/python/treadmill/tests/runtime/linux/image/native_test.py
+++ b/lib/python/treadmill/tests/runtime/linux/image/native_test.py
@@ -411,6 +411,7 @@ class NativeImageTest(unittest.TestCase):
             mock.call(
                 os.path.join(base_dir, 'services'),
                 finish_timeout=5000,
+                finish_commands=[],
             ),
             mock.call().write(),
         ])


### PR DESCRIPTION
 * subproc: Add new `subproc.resolve_argv` function
 * linux.run: Use new pid1 ability to close extra FDs in container.
 * deprecated: Add simple deprecation warning decorator
 * Fix UnboundLocalError: local variable 'tmpfile' referenced before assignment
 * Forward sockets: Use new pid1 ability to cleanup fds in container.
 * Add ktfwd path in manifest to install
 * Allow plugin to add container finish commands.
 * Remove redundant concept doc and have better cmdline doc
 * Add support for PATCH in application REST API